### PR TITLE
disable complete button if state not changed

### DIFF
--- a/client/components/complete.js
+++ b/client/components/complete.js
@@ -39,7 +39,7 @@ class Complete extends Component {
           value={this.state.checked}
           onChange={this.toggleChecked}
         />
-        <Button onClick={this.emitChange} className="button-secondary">Save and continue</Button>
+        <Button disabled={this.props.checkChanged && this.props.complete === this.state.checked} onClick={this.emitChange} className="button-secondary">Save and continue</Button>
       </div>
     )
   }

--- a/client/pages/sections/protocols/protocol-sections.js
+++ b/client/pages/sections/protocols/protocol-sections.js
@@ -72,7 +72,13 @@ class ProtocolSections extends Component {
               onFieldChange={(key, value) => updateItem({ [key]: value })}
               save={save}
             />
-            <Complete type="protocol" complete={values.complete} onChange={this.setCompleted} buttonClassName="button-secondary" />
+            <Complete
+              type="protocol"
+              complete={values.complete}
+              onChange={this.setCompleted}
+              buttonClassName="button-secondary"
+              checkChanged
+            />
           </div>
         </Expandable>
       </section>


### PR DESCRIPTION
We _might_ want to improve the interaction here, we also might not. This change checks the initial state of the complete component is different from the current checkbox state, so if you haven't changed the checkbox you can't submit the change. Opt in with a `checkChanged` flag as only desirable on protocols