### PR TITLE
Filter options before trying to render

### DIFF
--- a/client/components/field.js
+++ b/client/components/field.js
@@ -32,7 +32,7 @@ class Field extends Component {
   }
 
   mapOptions(options = []) {
-    return options.map(option => {
+    return options.filter(Boolean).map(option => {
       if (!option.reveal) {
         return option;
       }


### PR DESCRIPTION
When adding an "other" species in a species selector the values are updated immediately with an `undefined` value on cicking the other checkbox, until a value is entered in the text box.

This causes any accompanying playback of the species selection to error as the option provided to a "select from the previously selected species" checkbox group has an undefined option.

Fix this by filtering the options before attempting to render them.