### PR TITLE
Update slate-react and remove local version

### DIFF
--- a/client/components/editor/review.js
+++ b/client/components/editor/review.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Editor } from '@lennym/slate-react';
+import { Editor } from 'slate-react';
 import RTEditor from './editor';
 
 class ReviewTextEditor extends RTEditor {

--- a/client/components/editor/text-editor.js
+++ b/client/components/editor/text-editor.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import classnames from 'classnames';
-import { Editor } from '@lennym/slate-react';
+import { Editor } from 'slate-react';
 import {
   ic_format_bold,
   ic_format_italic,

--- a/package-lock.json
+++ b/package-lock.json
@@ -202,44 +202,6 @@
         }
       }
     },
-    "@lennym/slate-react": {
-      "version": "0.21.16",
-      "resolved": "https://registry.npmjs.org/@lennym/slate-react/-/slate-react-0.21.16.tgz",
-      "integrity": "sha512-iKlK9m2dQm85pmuvZC9ctpENm6/eBXSwn+xn6mHJ7ac1Q6lMOm2ixrk66GuzljWtjrIa4iBn35X2WtviQTic7w==",
-      "requires": {
-        "debug": "^3.1.0",
-        "get-window": "^1.1.1",
-        "is-window": "^1.0.2",
-        "lodash": "^4.1.1",
-        "memoize-one": "^4.0.0",
-        "prop-types": "^15.5.8",
-        "react-immutable-proptypes": "^2.1.0",
-        "selection-is-backward": "^1.0.0",
-        "slate-base64-serializer": "^0.2.94",
-        "slate-dev-environment": "^0.2.1",
-        "slate-hotkeys": "^0.2.8",
-        "slate-plain-serializer": "^0.6.33",
-        "slate-prop-types": "^0.5.24",
-        "slate-react-placeholder": "^0.1.12",
-        "tiny-invariant": "^1.0.1",
-        "tiny-warning": "^0.0.3"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
-        }
-      }
-    },
     "@types/node": {
       "version": "10.12.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.2.tgz",
@@ -3359,8 +3321,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "optional": true
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "aproba": {
           "version": "1.2.0",
@@ -3381,14 +3342,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "optional": true
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3403,20 +3362,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "optional": true
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "optional": true
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "optional": true
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3533,8 +3489,7 @@
         "inherits": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "optional": true
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "ini": {
           "version": "1.3.5",
@@ -3546,7 +3501,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3561,7 +3515,6 @@
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3569,14 +3522,12 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "optional": true
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         },
         "minipass": {
           "version": "2.2.4",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3595,7 +3546,6 @@
           "version": "0.5.1",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3676,8 +3626,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "optional": true
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3689,7 +3638,6 @@
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3775,8 +3723,7 @@
         "safe-buffer": {
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "optional": true
+          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3812,7 +3759,6 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3832,7 +3778,6 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3876,14 +3821,12 @@
         "wrappy": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "optional": true
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "yallist": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
-          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-          "optional": true
+          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
         }
       }
     },
@@ -6906,9 +6849,9 @@
       }
     },
     "slate-base64-serializer": {
-      "version": "0.2.94",
-      "resolved": "https://registry.npmjs.org/slate-base64-serializer/-/slate-base64-serializer-0.2.94.tgz",
-      "integrity": "sha512-jltk0PwOS1lu/TRHTN/qW67+VSXlbX1d0GottPloKjYwHBbH47GVT/G+hmkOdrGXzV7P6220BvQwN8Xq2RaJ5A==",
+      "version": "0.2.95",
+      "resolved": "https://registry.npmjs.org/slate-base64-serializer/-/slate-base64-serializer-0.2.95.tgz",
+      "integrity": "sha512-WK8roQUQBM7lHXNS6HYNmMSJ5tJmuoLeZkHJEHWCEl+1op1m5sC2onzBfpIRNP8AijlZ3m+lGlxfLO+3VtBMxw==",
       "requires": {
         "isomorphic-base64": "^1.0.2"
       }
@@ -6931,19 +6874,19 @@
       }
     },
     "slate-plain-serializer": {
-      "version": "0.6.33",
-      "resolved": "https://registry.npmjs.org/slate-plain-serializer/-/slate-plain-serializer-0.6.33.tgz",
-      "integrity": "sha512-dkbWQvB9FA/qN3HfkQ++xksaBHZsa6NCBG42OV70Y2wLSjN7Ym8NzQMR4bb5i67kL+ko+TXJ0Qg2sNiOEATCNQ=="
+      "version": "0.6.34",
+      "resolved": "https://registry.npmjs.org/slate-plain-serializer/-/slate-plain-serializer-0.6.34.tgz",
+      "integrity": "sha512-NuP00YRZxepDWB3c+SUW0aKsA+RFLw3Lrl3g6011SKNsBlPR9TZlvOy8VqyNCHhBdpyiT9IoIDuA69D+r5q7TA=="
     },
     "slate-prop-types": {
-      "version": "0.5.24",
-      "resolved": "https://registry.npmjs.org/slate-prop-types/-/slate-prop-types-0.5.24.tgz",
-      "integrity": "sha512-ZYgu3KPpvrOZ8a+bNPoxpVmTn3Xu5Gf+S2ooaZsfUbsq3JvndeTpyk3d3xmBX57w1Fq3qZn3KuErUu6IPSbg6w=="
+      "version": "0.5.25",
+      "resolved": "https://registry.npmjs.org/slate-prop-types/-/slate-prop-types-0.5.25.tgz",
+      "integrity": "sha512-ZttMvprRhzFlBhcd9CIrZkkEDPpKdOIYsdiX4LLT7rZdzSi5CsUSipjQBanWHwr+WDF2kRiDpK7Z5M1CaT/hHA=="
     },
     "slate-react": {
-      "version": "0.21.15",
-      "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.21.15.tgz",
-      "integrity": "sha512-yn3tu1Q6rBB2hYrnqE17+7eLy9Lxx7R7HdDFS02Bi6puYBoUa7RmwlwWCFAhyi9jUuaCa8pbXwZyUujDFV5DXQ==",
+      "version": "0.21.16",
+      "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.21.16.tgz",
+      "integrity": "sha512-zjgQR3tonOmqDCiWn3g+BOw7vR5c1pFN/Iri7AXmzviqRyChWSUM3bemw7ovmb1i77yfsAeQmPxW+DPKSE39GA==",
       "requires": {
         "debug": "^3.1.0",
         "get-window": "^1.1.1",
@@ -6953,12 +6896,12 @@
         "prop-types": "^15.5.8",
         "react-immutable-proptypes": "^2.1.0",
         "selection-is-backward": "^1.0.0",
-        "slate-base64-serializer": "^0.2.94",
+        "slate-base64-serializer": "^0.2.95",
         "slate-dev-environment": "^0.2.1",
         "slate-hotkeys": "^0.2.8",
-        "slate-plain-serializer": "^0.6.33",
-        "slate-prop-types": "^0.5.24",
-        "slate-react-placeholder": "^0.1.12",
+        "slate-plain-serializer": "^0.6.34",
+        "slate-prop-types": "^0.5.25",
+        "slate-react-placeholder": "^0.1.13",
         "tiny-invariant": "^1.0.1",
         "tiny-warning": "^0.0.3"
       },
@@ -6979,9 +6922,9 @@
       }
     },
     "slate-react-placeholder": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/slate-react-placeholder/-/slate-react-placeholder-0.1.12.tgz",
-      "integrity": "sha512-QBCLuRRrWhA7Igj6tgDsLPz5hnmMKBcknb7auXH21WC5L0OvT/oSd9qbyuHg36VLae3JjzQtN1+gXe2VWRWh1g=="
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/slate-react-placeholder/-/slate-react-placeholder-0.1.13.tgz",
+      "integrity": "sha512-0uWXoiKrh59tQITPOoU4NBFETD8jFWkd9rBl/YE9i+wRtlq4s1O52Xj3luPmRhK6p9Fu2kxghD/r/ER1J/vPuw=="
     },
     "slice-ansi": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   },
   "homepage": "https://github.com/UKHomeOffice/peephole#readme",
   "dependencies": {
-    "@lennym/slate-react": "^0.21.16",
     "@ukhomeoffice/frontend-toolkit": "^2.2.2",
     "@ukhomeoffice/react-components": "^0.6.0",
     "babel-loader": "^7.1.5",
@@ -53,7 +52,7 @@
     "redux-logger": "^3.0.6",
     "redux-thunk": "^2.3.0",
     "slate": "^0.44.9",
-    "slate-react": "^0.21.15",
+    "slate-react": "^0.21.16",
     "webpack": "^4.23.1",
     "webpack-cli": "^3.1.2"
   },


### PR DESCRIPTION
The bugfix that we needed has now been merged and published in the main version of slate-react so we can get rid of my hacky version.