### PR TITLE
Force SSL for production environments

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,3 +1,4 @@
 module.exports = {
-  port: process.env.PORT || 8080
+  port: process.env.PORT || 8080,
+  ssl: process.env.NODE_ENV === 'production'
 };

--- a/lib/app.js
+++ b/lib/app.js
@@ -2,10 +2,11 @@ const path = require('path');
 
 const express = require('express');
 const morgan = require('morgan');
+const ssl = require('express-enforces-ssl');
 const react = require('express-react-views');
 const homeOffice = require('@ukhomeoffice/frontend-toolkit');
 
-module.exports = () => {
+module.exports = settings => {
 
   const app = express();
 
@@ -17,6 +18,10 @@ module.exports = () => {
 
   app.use('/public', express.static(path.resolve(__dirname, '../public')));
   app.use('/public', express.static(homeOffice.assets));
+
+  if (settings.ssl) {
+    app.use(ssl());
+  }
 
   app.use(morgan('dev'));
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3019,6 +3019,11 @@
         "vary": "~1.1.2"
       }
     },
+    "express-enforces-ssl": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/express-enforces-ssl/-/express-enforces-ssl-1.1.0.tgz",
+      "integrity": "sha1-zynGphxb3YAuLH7SZaSpjnSH0aw="
+    },
     "express-react-views": {
       "version": "0.10.5",
       "resolved": "https://registry.npmjs.org/express-react-views/-/express-react-views-0.10.5.tgz",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "details-element-polyfill": "^2.3.0",
     "docx": "^4.7.0",
     "express": "^4.16.4",
+    "express-enforces-ssl": "^1.1.0",
     "express-react-views": "^0.10.5",
     "file-saver": "^2.0.0",
     "immutable": "^3.8.2",


### PR DESCRIPTION
If a user hits a production (i.e. any heroku) endpoint on plain http then redirect to a secure connection.