### PR TITLE
Only allow "production" and "development" webpack modes

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,9 @@
 const path = require('path');
 
+const mode = process.env.NODE_ENV === 'production' ? 'production' : 'development';
+
 module.exports = {
-  mode: process.env.NODE_ENV || 'development',
+  mode,
   entry: [
     './client/index'
   ],


### PR DESCRIPTION
Heroku CI passes a `NODE_ENV` of `test`, and webpack throws an error if given a mode of anything other then prod or dev. Instead set the mode to be development in all cases which are not explicitly production.