### PR TITLE
*BLOCKED* Add page numbers to the footer (WIP)

### DIFF
--- a/client/components/download-link/renderers/docx.js
+++ b/client/components/download-link/renderers/docx.js
@@ -51,6 +51,23 @@ const addStyles = doc => {
     .color('999999')
     .italics();
 
+    doc.Styles.createParagraphStyle('footerText', 'Footer Text')
+    .basedOn('Normal')
+    .next('Normal')
+    .quickFormat()
+    .font('Helvetica')
+    .size(20);
+
+  return doc;
+};
+
+const addPageNumbers = (doc) => {
+  doc.Footer.createParagraph()
+    .addRun(new TextRun('Page ').pageNumber())
+    .addRun(new TextRun(' of ').numberOfTotalPages())
+    .style('footerText')
+    .right();
+
   return doc;
 };
 
@@ -449,6 +466,7 @@ module.exports = {
       .then(() => new Document())
       .then(doc => addStyles(doc))
       .then(doc => renderDocument(doc, sections, values))
+      .then(doc => addPageNumbers(doc))
       .then(doc => pack(doc, values.title));
   }
 };


### PR DESCRIPTION
This works but there is a known bug in docx that seems to be duplicating header / footer content:
https://github.com/dolanmiu/docx/issues/259

so you get a repeated page number:
![dupe page numbers](https://i.imgur.com/slIUteX.png)
