### PR TITLE
Fix download links on project list page

### DIFF
--- a/client/components/download-link/index.js
+++ b/client/components/download-link/index.js
@@ -4,8 +4,8 @@ import classnames from 'classnames';
 import docxRenderer from './renderers/docx';
 import pplRenderer from './renderers/ppl';
 
-const mapStateToProps = (state) => {
-  const project = state.project;
+const mapStateToProps = (state, props) => {
+  const project = state.project || state.projects.find(project => project.id === props.project);
 
   return {
     values: project,


### PR DESCRIPTION
Fixing the download links in the project sections page broke them in the project list, this should make them work in both places.