### PR TITLE
Remove export of protocol setup section

### DIFF
--- a/client/components/download-link/renderers/docx.js
+++ b/client/components/download-link/renderers/docx.js
@@ -338,8 +338,6 @@ const renderProtocol = (doc, name, section, values) => {
 };
 
 const renderProtocolsSection = (doc, subsection, values) => {
-  renderFields(doc, subsection.setup, values);
-
   (values['protocols'] || []).forEach(protocolValues => {
     renderField(doc, subsection.fields[0], protocolValues);
 


### PR DESCRIPTION
Since it no longer exists then trying to explicitly export it into a document causes it to throw an error.