### PR TITLE
Prevent text editors getting really tall

### DIFF
--- a/assets/scss/_editor.scss
+++ b/assets/scss/_editor.scss
@@ -12,6 +12,9 @@
 
   [data-slate-editor] {
     min-height: 200px;
+    max-height: 600px;
+    max-height: 90vh;
+    overflow: auto;
     padding: 5px;
   }
 


### PR DESCRIPTION
So the editor controls stay visible at the top of the screen even when the content is really long.

Use two max height declarations because not all brosers support `vh` yet.