### PR TITLE
Remove max height on readonly text editors

### DIFF
--- a/assets/scss/_editor.scss
+++ b/assets/scss/_editor.scss
@@ -106,6 +106,7 @@
   > [data-slate-editor] {
     min-height: 0px;
     padding-left: 0;
+    max-height: none;
   }
 }
 


### PR DESCRIPTION
The max height was added to editors in edit mode to keep the controls on the screen, but needs to be removed from readonly editors because it makes no sense.