### PR TITLE
Remove link to project list from project view

### DIFF
--- a/client/pages/project.js
+++ b/client/pages/project.js
@@ -20,7 +20,6 @@ const Index = ({ establishment, project, onComplete = () => window.alert('Submit
         <DownloadLink project={project.id} label="Word (.docx)" renderer="docx" />
         <DownloadLink project={project.id} label="Backup (.ppl)" renderer="ppl" />
       </span>
-      <a href="/">Back to project list</a>
     </p>
     <ApplicationSummary onComplete={onComplete} />
   </Fragment>


### PR DESCRIPTION
The link to the project list makes sense in the drafting tool, but doesn't make sense at all when reviewing a submitted project.