### PR TITLE
Do not render section if project has not loaded

### DIFF
--- a/client/pages/section.js
+++ b/client/pages/section.js
@@ -1,5 +1,6 @@
 import React, { Fragment } from 'react';
 import { connect } from 'react-redux';
+import isEmpty from 'lodash/isEmpty';
 import { updateAndSave } from '../actions/projects';
 import DefaultSection from './sections';
 import SectionsLink from '../components/sections-link';
@@ -41,7 +42,7 @@ const mapDispatchToProps = (dispatch, { onUpdate }) => {
 class Section extends React.Component {
 
   render() {
-    if (!this.props.project) {
+    if (!this.props.project || isEmpty(this.props.project)) {
       return null;
     }
 


### PR DESCRIPTION
Because of the way that rich-text editors map `props.value` to `state.value` only on initialisation, if they initialise before they have a value then the state is not recalculated, and so the rich-text editor reimains empty once the data has loaded.

This means that refreshing a page with populated rich-text editors will appear to lose the values.

By waiting for the project to be loaded before allowing any sections to render then this is negated since all values will be present before any RTE components initialise.