### PR TITLE
Fix typo

### DIFF
--- a/client/components/download-link/renderers/docx.js
+++ b/client/components/download-link/renderers/docx.js
@@ -237,7 +237,7 @@ const renderSpeciesSelector = (doc, values, value) => {
     ...other
   ]);
 
-  if (!value.lenth) {
+  if (!value.length) {
     return renderNull(doc);
   }
 


### PR DESCRIPTION
`value.lenth` is not a thing, and will always resolve to false.