### PR TITLE
Remove headings from exported PDF

### DIFF
--- a/views/pdf/v0/protocols/index.jsx
+++ b/views/pdf/v0/protocols/index.jsx
@@ -71,12 +71,9 @@ const Protocol = ({ protocol, number }) => (
 const PDF = ({ protocols = [] }) => {
   return (
     <Fragment>
-      <h1>E. PROTOCOLS</h1>
-      <h2 className="subtitle">Summary table</h2>
       <div className="summary-table">
         <SummaryTable protocols={protocols} />
       </div>
-      <h2 className="subtitle">Protocol details</h2>
       {
         protocols.map((protocol, index) => <Protocol key={index} protocol={ protocol } number={ index + 1 } />)
       }


### PR DESCRIPTION
The headings take up space without adding any particular value in terms of understanding of the document.

Removed with agreement of design team.