### PR TITLE
Handle multiple paragraph nodes

### DIFF
--- a/client/components/download-link/renderers/docx.js
+++ b/client/components/download-link/renderers/docx.js
@@ -171,27 +171,29 @@ const renderNode = (doc, node) => {
 
     case 'paragraph':
       paragraph = new Paragraph();
-      node.nodes[0].leaves.forEach(leaf => {
-        text = new TextRun(leaf.text);
-        if (text) {
-          leaf.marks.forEach(mark => {
-            switch (mark.type) {
-              case 'bold':
-                text.bold();
-                break;
+      node.nodes.forEach(childNode => {
+        childNode.leaves.forEach(leaf => {
+          text = new TextRun(leaf.text);
+          if (text) {
+            (leaf.marks || []).forEach(mark => {
+              switch (mark.type) {
+                case 'bold':
+                  text.bold();
+                  break;
 
-              case 'italic':
-                text.italics();
-                break;
+                case 'italic':
+                  text.italics();
+                  break;
 
-              case 'underlined':
-                text.underline();
-                break;
-            }
-          });
-          paragraph.style('body');
-          paragraph.addRun(text);
-        }
+                case 'underlined':
+                  text.underline();
+                  break;
+              }
+            });
+            paragraph.style('body');
+            paragraph.addRun(text);
+          }
+        });
       });
       doc.addParagraph(paragraph);
       break;


### PR DESCRIPTION
There might be more than one node in a paragraph, so make sure we render them all.

Migrated projects have slightly different RTE data structures, and currently throw errors or render incomplete data. In particular some paragraphs contain mutiple nodes, and others have no leaf marks.