### PR TITLE
Remove state overwrite on willReceiveProps

### DIFF
--- a/client/components/repeater.js
+++ b/client/components/repeater.js
@@ -17,12 +17,6 @@ class Repeater extends Component {
     }
   }
 
-  componentWillReceiveProps({ items }) {
-    if (items) {
-      this.setState({ items })
-    }
-  }
-
   componentDidMount() {
     if (!this.props.initCollapsed && !this.state.items.length) {
       this.addItem();


### PR DESCRIPTION
This was used to handle a deferred data load, but this is now handled in a parent component, and is causing issues when saving local state asynchronously.

Remove the state overwrite so that the local state is the canonical version once the component is initially mounted.