### PR TITLE
Highlight inline comments in draft PPLs

### DIFF
--- a/assets/scss/_editor.scss
+++ b/assets/scss/_editor.scss
@@ -1,3 +1,5 @@
+@import "images";
+
 .editor {
   margin-top: $govuk-gutter / 2;
   background-color: $white;
@@ -101,6 +103,21 @@
       // top: 0;
     }
   }
+}
+
+.comment {
+  &:before {
+    content: '';
+    margin: 0 0.2em;
+    background: $comments;
+    background-size: 100%;
+    vertical-align: middle;
+    display: inline-block;
+    width: 1.5em;
+    height: 1.5em;
+  }
+  border-bottom: 3px solid #ffbf47;
+  background-color: #fff2d3;
 }
 
 .readonly {

--- a/client/components/editor/editor.js
+++ b/client/components/editor/editor.js
@@ -71,6 +71,8 @@ class Editor extends Component {
         return <em {...attributes}>{children}</em>;
       case 'underlined':
         return <u {...attributes}>{children}</u>;
+      case 'comment':
+        return <span className="comment" {...attributes}>{children}</span>;
       default:
         return next();
     }


### PR DESCRIPTION
Where an inspector has inserted comments inline into answers in a PPL draft they should be highlighted.