### PR TITLE
Fix table line-break CSS

### DIFF
--- a/assets/scss/_editor.scss
+++ b/assets/scss/_editor.scss
@@ -133,7 +133,6 @@
         border-top: none;
         border-bottom: none;
         border-right: none;
-        word-break: break-all;
         padding: 10px 20px;
       }
     }


### PR DESCRIPTION
It's causing line breaks to appear in the middle of words, which makes the content basically impossible to read.