### PR TITLE
Always show children of permissible purposes

### DIFF
--- a/assets/scss/projects.scss
+++ b/assets/scss/projects.scss
@@ -1258,4 +1258,19 @@ html.modal-open, html.modal-open body {
       }
     }
   }
+
+  // hack to always show sub-list for permissible purposes
+  // and to remove the checkbox for the reveal option
+  #permissible-purpose-translational-research {
+    & + label {
+      &:before,
+      &:after {
+        display: none;
+      }
+
+      & + .govuk-reveal {
+        display: block;
+      }
+    }
+  }
 }


### PR DESCRIPTION
Horrific hack to hide the checkbox and always show the reveal options

This is necessary to preserve the current data structure and allow the drafting tool to be backwards compatible