### PR TITLE
Refactor away circular dependency

### DIFF
--- a/client/components/diff-window.js
+++ b/client/components/diff-window.js
@@ -2,7 +2,7 @@ import React, { Fragment } from 'react';
 import { connect } from 'react-redux';
 import { fetchQuestionVersions } from '../actions/projects';
 import Modal from './modal';
-import Review from './review'
+import ReviewField from './review-field'
 import Tabs from './tabs';
 
 class DiffWindow extends React.Component {
@@ -49,7 +49,7 @@ class DiffWindow extends React.Component {
                             <a href="#" onClick={e => this.selectTab(e, 1)}>Previous version</a>
                           </Tabs>
                           <div className="panel light-grey">
-                            <Review
+                            <ReviewField
                               options={this.props.options}
                               type={this.props.type}
                               value={this.state.active === 0 ? granted : previous}
@@ -62,7 +62,7 @@ class DiffWindow extends React.Component {
                         <Fragment>
                           <h3>{changedFromGranted ? 'Current licence' : 'Previous version'}</h3>
                           <div className="panel light-grey">
-                            <Review
+                            <ReviewField
                               options={this.props.options}
                               type={this.props.type}
                               value={changedFromGranted ? granted : previous}
@@ -76,7 +76,7 @@ class DiffWindow extends React.Component {
                 <div className="govuk-grid-column-one-half">
                   <h3>Proposed</h3>
                   <div className="panel light-grey">
-                    <Review
+                    <ReviewField
                       options={this.props.options}
                       type={this.props.type}
                       value={this.props.value}

--- a/client/components/review-field.js
+++ b/client/components/review-field.js
@@ -1,0 +1,160 @@
+import React, { Fragment } from 'react';
+import { connect } from 'react-redux';
+import TextEditor from './editor';
+import speciesOptions from '../constants/species';
+
+import flatten from 'lodash/flatten';
+import values from 'lodash/values';
+import isUndefined from 'lodash/isUndefined';
+import isNull from 'lodash/isNull';
+import formatDate from 'date-fns/format';
+
+import { DATE_FORMAT } from '../constants';
+
+class ReviewField extends React.Component {
+
+  render() {
+    let value = this.props.value;
+    let options;
+    if (['checkbox', 'radio', 'select'].includes(this.props.type)) {
+      options = this.props.optionsFromSettings
+        ? this.props.settings[this.props.optionsFromSettings]
+        : this.props.options;
+    }
+
+    if ((this.props.type === 'radio' || this.props.type === 'select') && !isUndefined(value)) {
+      value = options.find(option => !isUndefined(option.value) ? option.value === value : option === value)
+    }
+
+    if (this.props.type === 'duration') {
+      return (
+        <dl className="inline">
+          <dt>Years</dt>
+          <dd>{(value || {}).years || 5}</dd>
+          <dt>Months</dt>
+          <dd>{(value || {}).months || 0}</dd>
+        </dl>
+      )
+    }
+
+    if (value && this.props.type === 'date') {
+      return formatDate(value, DATE_FORMAT.long);
+    }
+
+    if (this.props.type === 'species-selector') {
+      const project = this.props.project;
+      const other = project[`${this.props.name}-other`] || [];
+      value = value || [];
+      value = flatten([
+        ...value.map(val => {
+          if (val.indexOf('other') > -1) {
+            return project[`${this.props.name}-${val}`];
+          }
+          return val;
+        }),
+        ...other
+      ]);
+    }
+    if (this.props.type === 'checkbox' ||
+      this.props.type === 'species-selector' ||
+      this.props.type === 'location-selector' ||
+      this.props.type === 'objective-selector'
+    ) {
+      value = value || [];
+      if (!value.length) {
+        return (
+          <p>
+            <em>None selected</em>
+          </p>
+        );
+      }
+
+      if (this.props.type === 'species-selector') {
+        options = flatten(values(speciesOptions))
+      }
+
+      const getValue = value => {
+        const v = (options || []).find(option => option.value === value)
+        return v
+          ? v.label
+          : value
+      }
+
+      return (
+        <ul>
+          {
+            value.filter(v => options ? options.find(o => o.value === v) : true).map(value => (
+              <li key={value}>{getValue(value)}</li>
+            ))
+          }
+        </ul>
+      );
+    }
+    if (this.props.type === 'declaration') {
+      return <p>
+        {
+          this.props.value
+            ? 'Yes'
+            : 'No'
+        }
+      </p>
+    }
+
+    if (this.props.type === 'animal-quantities') {
+      const species = [
+        ...flatten((this.props.project.species || []).map(s => {
+          if (s.indexOf('other') > -1) {
+            return this.props.project[`species-${s}`];
+          }
+          return s;
+        })),
+        ...(this.props.project['species-other'] || [])
+      ].map(s => {
+        const opt = flatten(values(speciesOptions)).find(species => species.value === s);
+        return {
+          key: s && s.value,
+          title: opt ? opt.label : s,
+          value: this.props.project[`${this.props.name}-${s}`]
+        }
+      });
+
+      if (!species.length) {
+        return <p>
+          <em>No answer provided.</em>
+        </p>
+      }
+      return <dl className="inline">
+        {
+          species.map(s => (
+            <Fragment key={s.key}>
+              <dt>{s.title}:</dt>
+              <dd>{s.value ? s.value : <em>No answer provided.</em>}</dd>
+            </Fragment>
+          ))
+        }
+      </dl>
+    }
+    if (this.props.type === 'texteditor' && this.props.value) {
+      return <TextEditor {...this.props} readOnly={true} />;
+    }
+    if (!isUndefined(value) && !isNull(value) && value !== '') {
+      return <p>{value.review || value.label || value}</p>;
+    }
+    return (
+      <p>
+        <em>No answer provided.</em>
+      </p>
+    );
+  }
+
+}
+
+
+const mapStateToProps = ({ project, settings }) => {
+  return {
+    project,
+    settings
+  };
+}
+
+export default connect(mapStateToProps)(ReviewField);

--- a/client/components/review.js
+++ b/client/components/review.js
@@ -1,153 +1,15 @@
 import React, { Fragment } from 'react';
 import { HashLink as Link } from 'react-router-hash-link';
 import { connect } from 'react-redux';
-import TextEditor from './editor';
-import speciesOptions from '../constants/species';
 
 import Comments from './comments';
 import DiffWindow from './diff-window';
-import flatten from 'lodash/flatten';
-import values from 'lodash/values';
-import isUndefined from 'lodash/isUndefined';
-import isNull from 'lodash/isNull';
-import formatDate from 'date-fns/format';
-
-import { DATE_FORMAT } from '../constants';
+import ReviewField from './review-field';
 
 class Review extends React.Component {
 
   replay() {
-    let value = this.props.value;
-    let options;
-    if (['checkbox', 'radio', 'select'].includes(this.props.type)) {
-      options = this.props.optionsFromSettings
-        ? this.props.settings[this.props.optionsFromSettings]
-        : this.props.options;
-    }
-
-    if ((this.props.type === 'radio' || this.props.type === 'select') && !isUndefined(value)) {
-      value = options.find(option => !isUndefined(option.value) ? option.value === value : option === value)
-    }
-
-    if (this.props.type === 'duration') {
-      return (
-        <dl className="inline">
-          <dt>Years</dt>
-          <dd>{(value || {}).years || 5}</dd>
-          <dt>Months</dt>
-          <dd>{(value || {}).months || 0}</dd>
-        </dl>
-      )
-    }
-
-    if (value && this.props.type === 'date') {
-      return formatDate(value, DATE_FORMAT.long);
-    }
-
-    if (this.props.type === 'species-selector') {
-      const project = this.props.project;
-      const other = project[`${this.props.name}-other`] || [];
-      value = value || [];
-      value = flatten([
-        ...value.map(val => {
-          if (val.indexOf('other') > -1) {
-            return project[`${this.props.name}-${val}`];
-          }
-          return val;
-        }),
-        ...other
-      ]);
-    }
-    if (this.props.type === 'checkbox' ||
-      this.props.type === 'species-selector' ||
-      this.props.type === 'location-selector' ||
-      this.props.type === 'objective-selector'
-    ) {
-      value = value || [];
-      if (!value.length) {
-        return (
-          <p>
-            <em>None selected</em>
-          </p>
-        );
-      }
-
-      if (this.props.type === 'species-selector') {
-        options = flatten(values(speciesOptions))
-      }
-
-      const getValue = value => {
-        const v = (options || []).find(option => option.value === value)
-        return v
-          ? v.label
-          : value
-      }
-
-      return (
-        <ul>
-          {
-            value.filter(v => options ? options.find(o => o.value === v) : true).map(value => (
-              <li key={value}>{getValue(value)}</li>
-            ))
-          }
-        </ul>
-      );
-    }
-    if (this.props.type === 'declaration') {
-      return <p>
-        {
-          this.props.value
-            ? 'Yes'
-            : 'No'
-        }
-      </p>
-    }
-
-    if (this.props.type === 'animal-quantities') {
-      const species = [
-        ...flatten((this.props.project.species || []).map(s => {
-          if (s.indexOf('other') > -1) {
-            return this.props.project[`species-${s}`];
-          }
-          return s;
-        })),
-        ...(this.props.project['species-other'] || [])
-      ].map(s => {
-        const opt = flatten(values(speciesOptions)).find(species => species.value === s);
-        return {
-          key: s && s.value,
-          title: opt ? opt.label : s,
-          value: this.props.project[`${this.props.name}-${s}`]
-        }
-      });
-
-      if (!species.length) {
-        return <p>
-          <em>No answer provided.</em>
-        </p>
-      }
-      return <dl className="inline">
-        {
-          species.map(s => (
-            <Fragment key={s.key}>
-              <dt>{s.title}:</dt>
-              <dd>{s.value ? s.value : <em>No answer provided.</em>}</dd>
-            </Fragment>
-          ))
-        }
-      </dl>
-    }
-    if (this.props.type === 'texteditor' && this.props.value) {
-      return <TextEditor {...this.props} readOnly={true} />;
-    }
-    if (!isUndefined(value) && !isNull(value) && value !== '') {
-      return <p>{value.review || value.label || value}</p>;
-    }
-    return (
-      <p>
-        <em>No answer provided.</em>
-      </p>
-    );
+    return <ReviewField {...this.props} />;
   }
 
   changedBadge = () => {
@@ -207,13 +69,11 @@ class Review extends React.Component {
 }
 
 
-const mapStateToProps = ({ project, settings, application: { readonly } = {}, changes : { latest = [], granted = [] } = {} }, ownProps) => {
+const mapStateToProps = ({ application: { readonly } = {}, changes : { latest = [], granted = [] } = {} }, ownProps) => {
   const key = `${ownProps.prefix || ''}${ownProps.name}`;
   const changedFromGranted = granted.includes(key);
   const changedFromLatest = latest.includes(key);
   return {
-    project,
-    settings,
     readonly: ownProps.readonly || readonly,
     changedFromLatest,
     changedFromGranted


### PR DESCRIPTION
`Review` was depending on `DiffWindow` which was depending back on `Review`. `DiffWindow` didn't need _most_ of what was being provided in `Review` anyway.

Refactor out the common elements to remove the circular dependency and have `Review` and `DiffWindow` depend on the single common child component.