### PR TITLE
Add unique key prop to step title replay

### DIFF
--- a/client/pages/sections/protocols/steps.js
+++ b/client/pages/sections/protocols/steps.js
@@ -78,7 +78,7 @@ class Step extends Component {
             }
           </h3>
           {
-            completed && values.title && <TextEditor value={values.title} readOnly={true} />
+            completed && values.title && <TextEditor value={values.title} readOnly={true} key={values.title} />
           }
         </Fragment>
         {


### PR DESCRIPTION
`TextEditor` components don't update their internal state when receiving new props, and so reordering steps doesn't update the titles.

By adding a key prop then the components completely re-initialise when the value changes, and so the state is reset to the new value correctly.

See https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html#recommendation-fully-uncontrolled-component-with-a-key