### PR TITLE
Fix legacy species rendering inside protocol summary

### DIFF
--- a/client/pages/sections/granted/summary-table.js
+++ b/client/pages/sections/granted/summary-table.js
@@ -31,9 +31,10 @@ const SummaryTable = ({ protocols, isLegacy }) => (
             const species = !isLegacy
               ? (protocol.speciesDetails || []).filter(s => s.name)
               : (protocol.species || []).map(s => {
+                const matched = LEGACY_SPECIES.find(ls => ls.value === s.speciesId);
                 return {
                   ...s,
-                  name: LEGACY_SPECIES.find(ls => ls.value === s.speciesId).label
+                  name: matched ? matched.label : '-'
                 };
               });
             return species.map((s, speciesIndex) => (


### PR DESCRIPTION
Some species entries on protocols are missing a speciesId property. If that happens then render out a dash instead of throwing an error.