### PR TITLE
Fix potentially missing label on null species

### DIFF
--- a/client/pages/sections/granted/pdf-protocols.js
+++ b/client/pages/sections/granted/pdf-protocols.js
@@ -10,9 +10,10 @@ const Protocol = ({ protocol, number, sections, isLegacy }) => {
   const species = !isLegacy
     ? (protocol.speciesDetails || []).filter(s => s.name)
     : (protocol.species || []).map(s => {
+      const matched = LEGACY_SPECIES.find(ls => ls.value === s.speciesId);
       return {
         ...s,
-        name: LEGACY_SPECIES.find(ls => ls.value === s.speciesId).label
+        name: matched ? matched.label : '-'
       }
     });
   return (


### PR DESCRIPTION
Some production protocols have null species, which makes things crash when we expect them to always exist.

Same fix as #322 but somewhere else.