### PR TITLE
Wrap "date" review in a <p> tag

### DIFF
--- a/client/components/review-field.js
+++ b/client/components/review-field.js
@@ -37,7 +37,7 @@ class ReviewField extends React.Component {
       if (months > 12) {
         months = 0;
       }
-      
+
       if (years >= 5 || (!months && !years)) {
         years = 5;
         months = 0;
@@ -53,7 +53,7 @@ class ReviewField extends React.Component {
     }
 
     if (value && this.props.type === 'date') {
-      return formatDate(value, DATE_FORMAT.long);
+      return <p>{ formatDate(value, DATE_FORMAT.long) }</p>;
     }
 
     if (this.props.type === 'species-selector') {


### PR DESCRIPTION
The date was being output without any containing tag, which makes the whitespace look kind of broken.

<img width="658" alt="Screenshot 2019-08-12 at 16 52 41" src="https://user-images.githubusercontent.com/117398/62878767-a7e6c500-bd21-11e9-9d34-155c2d50c28e.png">
