### PR TITLE
Fix styling of remove buttons in "other species" selector

### DIFF
--- a/assets/scss/projects.scss
+++ b/assets/scss/projects.scss
@@ -1043,6 +1043,10 @@ html.modal-open, html.modal-open body {
     .govuk-form-group {
       margin-bottom: $govuk-gutter !important;
     }
+
+    .species-selector-other .govuk-button {
+      margin-bottom: 32px;
+    }
   }
 
   .add-more-animals {

--- a/client/components/other-species-selector.js
+++ b/client/components/other-species-selector.js
@@ -46,7 +46,7 @@ class OtherSpecies extends Component {
       <Fragment>
         {
           items.map((item, index) => (
-            <div key={index} className="flex">
+            <div key={index} className="flex species-selector-other">
               <div className="grow">
                 <Field
                   label={index === 0 && label}


### PR DESCRIPTION
There's a bit of GOVUK inherited styling that strips the margin-bottom off in a very annoying way. Add it back here.