### PR TITLE
Fix mapping over undefined fields

### DIFF
--- a/client/pages/sections/protocols/protocol-sections.js
+++ b/client/pages/sections/protocols/protocol-sections.js
@@ -62,7 +62,7 @@ class ProtocolSections extends PureComponent {
 
     const noAnswer = <em>No answer provided</em>;
 
-    const fields = Object.values(sections).map(s => s.fields.map(field => field.name)) || [];
+    const fields = Object.values(sections).map(s => (s.fields || []).map(field => field.name));
 
     return (
       <section className={classnames('protocol', { complete: values.complete || readonly, readonly })}>

--- a/client/pages/sections/protocols/sections.js
+++ b/client/pages/sections/protocols/sections.js
@@ -117,16 +117,20 @@ const ProtocolSections = ({ sections, protocolState, editable, newComments, ...p
   return (
   <Accordion open={getOpenSection(protocolState, editable, sections)} toggleAll={!props.pdf}>
     {
-      Object.keys(sections).sort(sortGranted(sections, props.isGranted)).filter(section => !sections[section].show || sections[section].show(props)).map((section, sectionIndex) => (
-        <Fragment key={section}>
-          <ChangedBadge fields={sections[section].fields.map(field => field.name)} />
-          <ExpandingPanel alwaysUpdate={section === 'conditions' || section === 'authorisations'} key={section} title={getTitle(sections[section], newComments, props.values)}>
-            {
-              getSection(section, { ...props, protocolState, editable, ...sections[section], sectionsLength: size(sections), sectionIndex })
-            }
-          </ExpandingPanel>
-        </Fragment>
-      ))
+      Object.keys(sections)
+        .sort(sortGranted(sections, props.isGranted))
+        .filter(section => !sections[section].show || sections[section].show(props))
+        .map((section, sectionIndex) => {
+          const fields = (sections[section].fields || []).map(field => field.name);
+          return <Fragment key={section}>
+            <ChangedBadge fields={fields} />
+            <ExpandingPanel alwaysUpdate={section === 'conditions' || section === 'authorisations'} key={section} title={getTitle(sections[section], newComments, props.values)}>
+              {
+                getSection(section, { ...props, protocolState, editable, ...sections[section], sectionsLength: size(sections), sectionIndex })
+              }
+            </ExpandingPanel>
+          </Fragment>
+        })
     }
   </Accordion>
 )}


### PR DESCRIPTION
Not all PPL sections have fields, and trying to map over sections which do not have fields throws an error.