### PR TITLE
Fix changed indicators inside protocols

### DIFF
--- a/client/components/changed-badge.js
+++ b/client/components/changed-badge.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 const ChangedBadge = ({ fields = [], latest = [], granted = [] }) => {
-
   const changedFrom = source => source.length && fields.some(field => source.some(change => change === field));
 
   if (changedFrom(latest)) {

--- a/client/components/changed-badge.js
+++ b/client/components/changed-badge.js
@@ -2,14 +2,16 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 const ChangedBadge = ({ fields = [], latest = [], granted = [] }) => {
-  const hasChangedFromLatest = latest.length && fields.some(field => latest.some(change => change.includes(field)));
-  if (hasChangedFromLatest) {
+
+  const changedFrom = source => source.length && fields.some(field => source.some(change => change === field));
+
+  if (changedFrom(latest)) {
     return <span className="badge changed">changed</span>;
   }
-  const hasChangedFromGranted = granted.length && fields.some(field => granted.some(change => change.includes(field)));
-  if (hasChangedFromGranted) {
+  if (changedFrom(granted)) {
     return <span className="badge">amended</span>;
   }
+
   return null;
 };
 

--- a/client/pages/sections/protocols/protocol-sections.js
+++ b/client/pages/sections/protocols/protocol-sections.js
@@ -62,7 +62,17 @@ class ProtocolSections extends PureComponent {
 
     const noAnswer = <em>No answer provided</em>;
 
-    const fields = Object.values(sections).map(s => (s.fields || []).map(field => field.name));
+    const fields = Object.values(sections)
+      .reduce((list, section) => {
+        if (section.repeats && values[section.repeats]) {
+          values[section.repeats].forEach(repeater => {
+            list.push.apply(list, (section.fields || []).map(f => `${section.repeats}.${repeater.id}.${f.name}`));
+          });
+          return list;
+        }
+        return list.concat((section.fields || []).map(field => field.name));
+      }, [])
+      .map(f => `protocols.${values.id}.${f}`);
 
     return (
       <section className={classnames('protocol', { complete: values.complete || readonly, readonly })}>

--- a/client/pages/sections/protocols/sections.js
+++ b/client/pages/sections/protocols/sections.js
@@ -76,6 +76,15 @@ const getOpenSection = (protocolState, editable, sections) => {
   });
 }
 
+const getFieldKeys = (section, values) => {
+  if (section.repeats) {
+    return (values[section.repeats] || []).reduce((list, repeater) => {
+      return list.concat((section.fields || []).map(f => `protocols.${values.id}.${section.repeats}.${repeater.id}.${f.name}`));
+    }, []);
+  }
+  return section.fields.map(f => `protocols.${values.id}.${f.name}`);
+};
+
 const getBadges = (section, newComments, values) => {
   let relevantComments;
   if (section.repeats) {
@@ -86,13 +95,15 @@ const getBadges = (section, newComments, values) => {
   }
   const numberOfNewComments = Object.values(relevantComments).reduce((total, comments) => total + (comments || []).length, 0);
 
+  const fields = getFieldKeys(section, values);
+
   return (
     <Fragment>
       {
         !!numberOfNewComments && <NewComments comments={numberOfNewComments} />
       }
       {
-        section.fields && <ChangedBadge fields={section.fields.map(f => f.name)} />
+        section.fields && <ChangedBadge fields={fields} />
       }
     </Fragment>
   )

--- a/client/pages/sections/protocols/steps.js
+++ b/client/pages/sections/protocols/steps.js
@@ -12,6 +12,7 @@ import TextEditor from '../../../components/editor';
 import ReviewFields from '../../../components/review-fields';
 import Repeater from '../../../components/repeater';
 import Fieldset from '../../../components/fieldset';
+import ChangedBadge from '../../../components/changed-badge';
 
 class Step extends Component {
   constructor(options) {
@@ -84,12 +85,12 @@ class Step extends Component {
     const { prefix, index, fields, values, updateItem, length, editable } = this.props;
 
     const completed = !editable || values.completed;
-
     return (
       <section
         className={classnames('step', { completed, editable })}
         ref={this.step}
       >
+        <ChangedBadge fields={[ prefix.substr(0, prefix.length - 1) ]} />
         <Fragment>
           {
             editable && completed && (
@@ -152,7 +153,7 @@ const Steps = ({ values, prefix, updateItem, editable, ...props }) => {
       <p className="grey">{props.hint}</p>
       <br />
       <Repeater
-        type="step"
+        type="steps"
         singular="step"
         prefix={prefix}
         items={values.steps}

--- a/client/reducers/changes.js
+++ b/client/reducers/changes.js
@@ -6,13 +6,11 @@ const INITIAL_STATE = {
 };
 
 const changedItems = (state = [], action) => {
-  if (state.includes(action.change)) {
-    return state;
-  }
-  return [
-    ...state,
-    action.change
-  ];
+  const paths = action.change.split('.').map((_, i, arr) => arr.slice(0, i + 1).join('.'));
+
+  return paths.reduce((arr, path) => {
+    return arr.includes(path) ? arr : [ ...arr, path ];
+  }, state);
 };
 
 const changes = (state = INITIAL_STATE, action) => {

--- a/client/schema/v0/index.js
+++ b/client/schema/v0/index.js
@@ -332,7 +332,7 @@ export default {
         granted: {
           review: GrantedProtocols
         },
-        repeats: 'protocol',
+        repeats: 'protocols',
         fields: [
           {
             name: 'title',

--- a/client/schema/v1/index.js
+++ b/client/schema/v1/index.js
@@ -1506,7 +1506,7 @@ each other.`,
             title: 'Steps',
             hint: 'A step can be a single procedure or a combination of procedures to achieve an outcome. You will be able to reorder your steps at any time before you send your application to the Home Office, but they should be broadly chronological, with the final step being a method of killing or the last regulated procedure.',
             footer: 'Once you’ve created a list of steps, you need to add information about adverse effects, controls and limitations, and humane endpoints to each one.​',
-            repeats: 'step',
+            repeats: 'steps',
             granted: {
               order: 6,
               review: GrantedSteps


### PR DESCRIPTION
Where fields change inside repeating sections we need to check the complete path to detect if a field has changed, and not simply the top-level field name.