### PR TITLE
Don't render list selection highlights in read-only editors

### DIFF
--- a/client/components/editor/list/renderers.js
+++ b/client/components/editor/list/renderers.js
@@ -1,8 +1,8 @@
 import React from 'react';
 
 const renderBlock = (props, editor, next) => {
-  const { attributes, children, node } = props;
-  const isCurrentItem = editor.getItemsAtRange().contains(node);
+  const { attributes, children, node, readOnly } = props;
+  const isCurrentItem = !readOnly && editor.getItemsAtRange().contains(node);
 
   switch (node.type) {
     case 'bulleted-list':


### PR DESCRIPTION
A blue left border style was added to editors to help highlight the selected list items when editing. This is still being rendered in read-only mode, and looks odd.

Remove the attributes from the rendered HTML when rendering read-only editors.