### PR TITLE
Add hotkey for clearing inline comments

### DIFF
--- a/client/components/editor/marks/handlers.js
+++ b/client/components/editor/marks/handlers.js
@@ -7,8 +7,16 @@ const isCodeHotkey = isKeyHotkey('mod+`');
 const isSuperscriptHotkey = isKeyHotkey('mod+=');
 const isSubscriptHotkey = isKeyHotkey('mod+shift++');
 
+const isClearCommentHotkey = isKeyHotkey('mod+k');
+
+
 export const onKeyDown = (event, editor, next) => {
   let mark;
+
+  if (isClearCommentHotkey(event)) {
+    editor.removeMark('comment');
+    return next();
+  }
 
   if (isBoldHotkey(event)) {
     mark = 'bold';


### PR DESCRIPTION
Comment highlighting can't easily be removed in some cases, and in at least one case where the entire content is highlighted cannot be removed at all.

Add a hotkey combination that allows for complete removal of comments without having to delete the content.