### PR TITLE
Fix colspan and rowspans for simple tables

### DIFF
--- a/client/components/download-link/renderers/docx-renderer.js
+++ b/client/components/download-link/renderers/docx-renderer.js
@@ -124,7 +124,7 @@ export default (application, sections, values, updateImageDimensions) => {
     let colcount = 0;
 
     // calculate the actual dimensions of the table
-    rows.forEach(row => {
+    rows.forEach((row, rowIndex) => {
       const cells = row.nodes;
 
       colcount = Math.max(
@@ -135,7 +135,12 @@ export default (application, sections, values, updateImageDimensions) => {
       // reduce rowspans by one for next row.
       rowspans = [
         ...rowspans,
-        ...cells.map(cell => get(cell, 'data.rowSpan', 1) || 1)
+        ...cells.map(cell => {
+          const rs = get(cell, 'data.rowSpan', 1);
+          // All falsy values _except_ 0 should be 1
+          // rowspan === 0 => fill the rest of the table
+          return rs || (rs === 0 ? rows.length - rowIndex : 1);
+        })
       ]
         .map(s => s - 1)
         .filter(Boolean);
@@ -155,8 +160,10 @@ export default (application, sections, values, updateImageDimensions) => {
         }
 
         // store rowspan to be taken into account in the next row
-        rowspanStore[colIndex] = get(cell, 'data.rowSpan', 1) || 1;
-        const colspan = get(cell, 'data.colSpan', 1) || 1;
+        const rs = get(cell, 'data.rowSpan', 1);
+        const cs = get(cell, 'data.colSpan', 1);
+        rowspanStore[colIndex] = rs || (rs === 0 ? rows.length - rowIndex : 1);
+        const colspan = cs || (cs === 0 ? colcount - colIndex : 1);
 
         // increase offset for next cell
         spanOffset += (colspan - 1);

--- a/client/components/download-link/renderers/docx-renderer.js
+++ b/client/components/download-link/renderers/docx-renderer.js
@@ -124,7 +124,7 @@ export default (application, sections, values, updateImageDimensions) => {
     let colcount = 0;
 
     // calculate the actual dimensions of the table
-    rows.forEach((row, rowIndex) => {
+    rows.forEach(row => {
       const cells = row.nodes;
 
       colcount = Math.max(
@@ -135,7 +135,7 @@ export default (application, sections, values, updateImageDimensions) => {
       // reduce rowspans by one for next row.
       rowspans = [
         ...rowspans,
-        ...cells.map(cell => get(cell, 'data.rowSpan', 1) || rows.length - rowIndex)
+        ...cells.map(cell => get(cell, 'data.rowSpan', 1) || 1)
       ]
         .map(s => s - 1)
         .filter(Boolean);
@@ -155,8 +155,8 @@ export default (application, sections, values, updateImageDimensions) => {
         }
 
         // store rowspan to be taken into account in the next row
-        rowspanStore[colIndex] = get(cell, 'data.rowSpan', 1) || rows.length - rowIndex;
-        const colspan = get(cell, 'data.colSpan', 1) || colcount - colIndex;
+        rowspanStore[colIndex] = get(cell, 'data.rowSpan', 1) || 1;
+        const colspan = get(cell, 'data.colSpan', 1) || 1;
 
         // increase offset for next cell
         spanOffset += (colspan - 1);


### PR DESCRIPTION
The default values for table cells' colspan and rowspan values were being erroneously set to large values. Fix that by defaulting them to 1 where the colspan or rowspan are null.