### PR TITLE
Fix lists with unwrapped text children

### DIFF
--- a/client/components/download-link/renderers/docx-renderer.js
+++ b/client/components/download-link/renderers/docx-renderer.js
@@ -334,6 +334,14 @@ export default (application, sections, values, updateImageDimensions) => {
       case 'image':
         doc.createImage(node.data.src, node.data.width, node.data.height);
         break;
+
+      default:
+        // if there is no matching type then it's probably a denormalised text node with no wrapping paragraph
+        // attempt to render with the node wrapped in a paragraph
+        if (node.text) {
+          renderNode(doc, { object: 'block', type: 'paragraph', nodes: [ node ] }, depth, paragraph)
+        }
+
     }
   }
 


### PR DESCRIPTION
The text editor normalises list items to always contain a paragraph, but this was done post migration so some legacy licences contain un-normalised list data.

Where likely occurrences of this are found - specifically where `renderNode` is called on a text node - then render the text node wrapped in a paragraph.