### PR TITLE
Use absolute values instead of % for Word export table column widths

### DIFF
--- a/client/components/download-link/renderers/docx-renderer.js
+++ b/client/components/download-link/renderers/docx-renderer.js
@@ -218,8 +218,8 @@ export default (application, sections, values, updateImageDimensions) => {
     return new Table({
       rows: rowcount,
       columns: colcount,
-      // setting to a large % enforces equal-width columns
-      columnWidths: Array(colcount).fill('500%')
+      // setting to a large number enforces equal-width columns
+      columnWidths: Array(colcount).fill('10000')
     });
   };
 


### PR DESCRIPTION
There are reports of Word on Windows reporting "illegal characters" in exported documents. Some investigation has tracked these down to be related to the percent symbols in table column widths.

Replacing the percentages with very large pixel values still fixes the issue with Pages on MacOS not setting widths correctly, but (hopefully) without causing problems on Word on Windows.