### PR TITLE
Remove "before" state from diffs

### DIFF
--- a/client/actions/projects.js
+++ b/client/actions/projects.js
@@ -209,7 +209,8 @@ const syncProject = (dispatch, getState) => {
 
   dispatch(isSyncing());
 
-  const patch = diff(state.savedProject, state.project);
+  const patch = diff(state.savedProject, state.project)
+    .map(d => d.kind === 'edit' ? omit(d, 'lhs') : d);
 
   const params = {
     state,


### PR DESCRIPTION
Sending the before state is not required to be able to apply the diff, and causes ~twice as much data as necessary to be transferred.