### PR TITLE
Add prefix to legacy animals sections

### DIFF
--- a/client/components/comments/index.js
+++ b/client/components/comments/index.js
@@ -75,10 +75,19 @@ class Comments extends Component {
   }
 }
 
-const mapStateToProps = ({ comments, application: { commentable, showComments } }, { field }) => ({
-  comments: comments[field],
-  commentable,
-  showComments
-});
+const mapStateToProps = ({ comments, application: { commentable, showComments } }, { field }) => {
+  const name = field.split('.').pop();
+  let allComments = comments[field];
+  // backwards compatibility fix for some comments being saved without a prefix
+  // merge comments saved with unprefixed name and full name
+  if (name !== field) {
+    allComments = [].concat(comments[name]).concat(comments[field]).filter(Boolean);
+  }
+  return {
+    comments: allComments,
+    commentable,
+    showComments
+  }
+};
 
 export default connect(mapStateToProps)(Comments);

--- a/client/pages/sections/protocols/legacy-animals.js
+++ b/client/pages/sections/protocols/legacy-animals.js
@@ -17,6 +17,7 @@ const LegacyAnimal = ({ updateItem, values, readonly, prefix, fields, index, edi
           onFieldChange={(key, value) => updateItem({ [key]: value })}
         />
         : <ReviewFields
+          prefix={prefix}
           fields={fields}
           values={values}
           editLink={`0#${prefix}`}


### PR DESCRIPTION
This was causing comments to be saved and loaded without a prefix. When loading comments use the prefixed and unprefixed field name and merge the two.