### PR TITLE
Hide removed conditions when reading licence

### DIFF
--- a/client/components/conditions/index.js
+++ b/client/components/conditions/index.js
@@ -22,7 +22,10 @@ function ConditionsPage({
     return null;
   }
   const [adding, setAdding] = useState(false);
-  const conditions = (values.conditions || []).filter(condition => condition.type === type);
+  const conditions = (values.conditions || [])
+    .filter(condition => condition.type === type)
+    // don't show deleted conditions in read-only mode
+    .filter(condition => editConditions || !condition.deleted);
 
   function save(vals) {
     setAdding(false);


### PR DESCRIPTION
If an automatically added condition has been removed by an inspector then it should be completely removed in non-edit mode and not rendered out to the screen.