### PR TITLE
Whitelist fields for comment duplication backwards compatability fix

### DIFF
--- a/client/components/comments/index.js
+++ b/client/components/comments/index.js
@@ -80,7 +80,8 @@ const mapStateToProps = ({ comments, application: { commentable, showComments } 
   let allComments = comments[field];
   // backwards compatibility fix for some comments being saved without a prefix
   // merge comments saved with unprefixed name and full name
-  if (name !== field) {
+  // whitelist the fields in legacy protocol animal questions as they are the only ones affected
+  if (name !== field && field.match(/^protocols\.[a-f0-9-]+\.item\./)) {
     allComments = [].concat(comments[name]).concat(comments[field]).filter(Boolean);
   }
   return {


### PR DESCRIPTION
There was a fix to include comments made on unprefixed field names for backwards compat with a bugfix for legacy animals section (https://github.com/UKHomeOffice/asl-projects/pull/376)

However, this now results in comments being duplicated for all fields which share a name in a repeated section and at the top level (e.g. `title`).

Fix this by whitelisting only to the original set of fields that was affected - namely those in a legacy PPL animals section.