### PR TITLE
Fix assorted issues with diff window states

### DIFF
--- a/client/components/diff-window.js
+++ b/client/components/diff-window.js
@@ -239,7 +239,7 @@ class DiffWindow extends React.Component {
   }
 }
 
-const mapStateToProps = ({ questionVersions }, { name }) => {
+const mapStateToProps = ({ questionVersions }, { name, value }) => {
   if (!questionVersions[name]) {
     return {
       loading: true,
@@ -252,8 +252,8 @@ const mapStateToProps = ({ questionVersions }, { name }) => {
     loading: false,
     previous,
     granted,
-    changedFromGranted: grantedId,
-    changedFromLatest: grantedId !== previousId
+    changedFromGranted: grantedId && granted !== value,
+    changedFromLatest: grantedId !== previousId && previous !== value
   };
 }
 


### PR DESCRIPTION
* Only try to load field data when a user tries to open the window. Currently all fields load their comparison when the component is rendered, which can result in _a lot_ of requests going at once.
* Add a loading state to handle the case where data is not available yet, instead of just rendering "No answer provided".
* Check if the granted id and the previous id are the same to determine whether to render one tab or two. Currently two tabs are shown even if the previous and granted versions are the same.