### PR TITLE
Don't load diff content on component mount

### DIFF
--- a/client/components/diff-window.js
+++ b/client/components/diff-window.js
@@ -28,10 +28,6 @@ class DiffWindow extends React.Component {
     this.setState({ active })
   }
 
-  componentDidMount() {
-    this.props.getPreviousVersions()
-  }
-
   diff(a, b) {
     let before;
     let after;


### PR DESCRIPTION
Only load the diff content once the user has clicked on the compare link to open the comparison.

For an inspector reviewing a PPL where a lot of changes have been made this fires off a large number of simultaneous requests on render, which can effectively DDoS themselves in certain network conditions and start throwing unexpected error messages.

Instead only make the request to load the content when the window is opened.

Note: this was meant to have come out in #388 but apparently got left behind and I've just seen the DDoS-ing in prod where it sends 30 requests on opening a protocol.