### PR TITLE
Make newly added comments editable

### DIFF
--- a/client/reducers/comments.js
+++ b/client/reducers/comments.js
@@ -11,7 +11,8 @@ const comments = (state = {}, action) => {
             id: action.id,
             comment: action.comment,
             author: action.author,
-            isNew: true
+            isNew: true,
+            isMine: true
           }
         ]
       }


### PR DESCRIPTION
Comments should be editable as soon as they are added, but because the `isMine` property comes from the server then they are only editable after a refresh.

Set all newly added comments to belong to the current user by default.