### PR TITLE
Don't render collapsed sections

### DIFF
--- a/client/components/expandable.js
+++ b/client/components/expandable.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import classnames from 'classnames';
 
 const hasTwoChildren = children => {
@@ -12,8 +12,23 @@ const Expandable = ({
   content,
   onHeaderClick,
   className
-}) => (
-  <div className={classnames('expandable', { expanded }, className)}>
+}) => {
+
+  function renderContent() {
+    if (!expanded) {
+      return null;
+    }
+    return <Fragment>
+      {
+        content && content
+      }
+      {
+        hasTwoChildren(children) ? children[1] : children
+      }
+    </Fragment>
+  }
+
+  return <div className={classnames('expandable', { expanded }, className)}>
     <div className="header" onClick={onHeaderClick}>
       {
         title && <h2>{title}</h2>
@@ -23,14 +38,9 @@ const Expandable = ({
       }
     </div>
     <div className={classnames('content', { hidden: !expanded })}>
-      {
-        content && content
-      }
-      {
-        hasTwoChildren(children) ? children[1] : children
-      }
+      { renderContent() }
     </div>
   </div>
-)
+};
 
 export default Expandable;

--- a/client/components/expanding-panel.js
+++ b/client/components/expanding-panel.js
@@ -32,17 +32,22 @@ export default function ExpandingPanel(props) {
     return open;
   }
 
+  function content() {
+    if (!isOpen()) {
+      return null;
+    }
+    return props.scrollToActive
+      ? React.Children.map(props.children, child => React.cloneElement(child, { ...props, scrollToTop }))
+      : props.children
+  }
+
   return (
     <section className={classnames('expanding-panel', { open: isOpen() }, props.className)}>
       <header onClick={() => toggle()}>
         <h3 ref={ref}>{ props.title }</h3>
       </header>
       <div className={classnames('content', { hidden: !isOpen() })}>
-        {
-          props.scrollToActive
-            ? React.Children.map(props.children, child => React.cloneElement(child, { ...props, scrollToTop }))
-            : props.children
-        }
+        { content() }
       </div>
     </section>
   )


### PR DESCRIPTION
Where a PPL has a large number of protocols and steps then the render overhead per keypress becomes very large. By not rendering collapsed sections at all then the performance can be greatly improved.