### PR TITLE
Keepalive when reviewing PPLs

### DIFF
--- a/client/actions/session.js
+++ b/client/actions/session.js
@@ -1,9 +1,12 @@
+import debounce from 'lodash/debounce';
 import sendMessage from './messaging';
+
+const debouncedSendMessage = debounce(sendMessage, 30000);
 
 export const keepAlive = () => {
   return () => {
     return Promise.resolve()
-      .then(() => sendMessage({ url: '/keepalive' }))
+      .then(() => debouncedSendMessage({ url: '/keepalive' }))
       .catch(err => console.error(err));
   };
 };

--- a/client/components/comments/add-comment.js
+++ b/client/components/comments/add-comment.js
@@ -13,6 +13,7 @@ class AddComment extends Component {
   };
 
   onChange = e => {
+    this.props.keepAlive();
     this.setState({
       comment: e.target.value
     })

--- a/client/pages/sections/protocols/protocol-sections.js
+++ b/client/pages/sections/protocols/protocol-sections.js
@@ -13,6 +13,8 @@ import ChangedBadge from '../../../components/changed-badge';
 import NewProtocolBadge from '../../../components/new-protocol-badge';
 import ReorderedBadge from '../../../components/reordered-badge';
 
+import { keepAlive } from '../../../actions/session';
+
 class ProtocolSections extends PureComponent {
   state = {
     expanded: this.props.editable && !this.props.values.deleted && (this.props.protocolState || !this.props.values.complete)
@@ -32,6 +34,7 @@ class ProtocolSections extends PureComponent {
   }
 
   toggleExpanded = () => {
+    this.props.keepAlive();
     this.setState({
       expanded: !this.state.expanded
     })
@@ -190,4 +193,4 @@ class ProtocolSections extends PureComponent {
 
 const mapStateToProps = ({ application: { schemaVersion }}) => ({ schemaVersion });
 
-export default withRouter(connect(mapStateToProps)(ProtocolSections));
+export default withRouter(connect(mapStateToProps, { keepAlive })(ProtocolSections));


### PR DESCRIPTION
If someone is typing a comment or navigating inside protocols then ping the server to keep the session alive.

If an inspector is reviewing an incredibly girthy PPL then it's reasonable that they might spend more than half an hour reviewing protocols.

Also make sure that keepalives are occasional. There's no need to ping more than once a minute no mater what the user is doing.