### PR TITLE
Bugfix - init protocols with lists

### DIFF
--- a/client/components/repeater.js
+++ b/client/components/repeater.js
@@ -35,7 +35,7 @@ class Repeater extends Component {
   addItem() {
     return Promise.resolve()
       .then(this.props.onBeforeAdd)
-      .then(() => this.update([ ...this.state.items, { id: uuid() } ]))
+      .then(() => this.update([ ...this.state.items, { id: uuid(), ...this.props.itemProps } ]))
       .then(this.props.onAfterAdd);
   }
 
@@ -187,6 +187,7 @@ Repeater.defaultProps = {
   addOnInit: true,
   addAnother: true,
   softDelete: false,
+  itemProps: {},
   onBeforeAdd: () => Promise.resolve(),
   onAfterAdd: () => Promise.resolve(),
   onBeforeRemove: () => Promise.resolve(),

--- a/client/pages/sections/protocols/protocols.js
+++ b/client/pages/sections/protocols/protocols.js
@@ -143,6 +143,7 @@ class Protocols extends PureComponent {
         addButtonBefore={protocols && protocols.length > 0 && protocols[0].title}
         addButtonAfter={true}
         softDelete={true}
+        itemProps={{ speciesDetails: [], steps: [] }}
         onAfterAdd={() => {
           window.scrollTo({
             top: document.body.scrollHeight,


### PR DESCRIPTION
* When adding an item to a repeater, use a prototype object, default {}