### PR TITLE
Bugfix - handle null speciesDetails

### DIFF
--- a/client/constants/conditions.js
+++ b/client/constants/conditions.js
@@ -24,7 +24,7 @@ export default {
       ]
     },
     reuse: {
-      include: protocol => some(protocol.speciesDetails, species => species.reuse),
+      include: protocol => some(protocol.speciesDetails.filter(Boolean), species => species.reuse),
       type: 'authorisation',
       versions: [
         {
@@ -34,7 +34,7 @@ export default {
       ]
     },
     'continued-use': {
-      include: protocol => some(protocol.speciesDetails, species => species['continued-use']),
+      include: protocol => some(protocol.speciesDetails.filter(Boolean), species => species['continued-use']),
       type: 'authorisation',
       versions: [
         {

--- a/client/pages/sections/protocols/animals.js
+++ b/client/pages/sections/protocols/animals.js
@@ -76,29 +76,9 @@ class Animals extends Component {
     this.setState({ adding: !this.state.adding });
   }
 
-  saveAnimalsAndAdvance = () => {
-    const species = this.props.values.species;
-    const speciesDetails = this.props.values.speciesDetails || [];
-    species.forEach(i => {
-      let item = flatten(values(SPECIES)).find(f => f.value === i);
-      if (item) {
-        item = item.label
-      }
-      else {
-        item = i;
-      }
-      if (some(speciesDetails, sd => sd.name === item)) {
-        return;
-      }
-      speciesDetails.push({ name: item, id: v4() })
-    });
-
-    this.props.onFieldChange('speciesDetails', speciesDetails);
-    this.props.advance();
-  }
-
   getItems = () => {
-    const { values: { speciesDetails = [] }, project } = this.props;
+    const { project } = this.props;
+    const speciesDetails = this.props.values.speciesDetails.filter(Boolean);
     let species = this.props.values.species || [];
 
     species = species.map(s => {

--- a/client/pages/sections/protocols/protocol-sections.js
+++ b/client/pages/sections/protocols/protocol-sections.js
@@ -79,14 +79,14 @@ class ProtocolSections extends PureComponent {
     const numberOfNewComments = Object.values(newComments)
       .reduce((total, comments) => total + (comments || []).length, 0);
 
-    const speciesDetails = values.speciesDetails && values.speciesDetails.filter(s => s.name);
+    const speciesDetails = values.speciesDetails && values.speciesDetails.filter(Boolean).filter(s => s.name);
 
     const noAnswer = <em>No answer provided</em>;
 
     const fields = Object.values(sections)
       .reduce((list, section) => {
         if (section.repeats && values[section.repeats]) {
-          values[section.repeats].forEach(repeater => {
+          values[section.repeats].filter(Boolean).forEach(repeater => {
             list.push.apply(list, (section.fields || []).map(f => `${section.repeats}.${repeater.id}.${f.name}`));
           });
           return list;

--- a/client/pages/sections/protocols/sections.js
+++ b/client/pages/sections/protocols/sections.js
@@ -78,7 +78,7 @@ const getOpenSection = (protocolState, editable, sections) => {
 
 const getFieldKeys = (section, values) => {
   if (section.repeats) {
-    return (values[section.repeats] || []).reduce((list, repeater) => {
+    return (values[section.repeats] || []).filter(Boolean).reduce((list, repeater) => {
       return list.concat((section.fields || []).map(f => `protocols.${values.id}.${section.repeats}.${repeater.id}.${f.name}`));
     }, []);
   }

--- a/client/schema/v1/index.js
+++ b/client/schema/v1/index.js
@@ -2368,7 +2368,7 @@ each other.`,
       },
       'reusing-animals': {
         title: 'Re-using animals',
-        show: project => some(project.protocols, protocol => some(protocol.speciesDetails, species => species.reuse)),
+        show: project => some(project.protocols, protocol => some(protocol.speciesDetails, species => (species || {}).reuse)),
         intro: 'You are seeing this section because you will be re-using animals during your project. If this is not correct, you can change this in Protocols.',
         fields: [
           {


### PR DESCRIPTION
Sometimes speciesDetails contains null entries, this breaks in a lot of places. Filter out null species details to avoid breaking the interface