### PR TITLE
Bugfix - dont hide comments labels in steps

### DIFF
--- a/assets/scss/projects.scss
+++ b/assets/scss/projects.scss
@@ -743,7 +743,7 @@ html.modal-open, html.modal-open body {
         }
       }
 
-      &.editable > .review .review a {
+      &.editable > .review .review a.edit-link {
         display: none;
       }
     }

--- a/client/components/review.js
+++ b/client/components/review.js
@@ -60,6 +60,7 @@ class Review extends React.Component {
               <p>
                 <Link
                   to={this.props.editLink || `#${this.props.name}`}
+                  className="edit-link"
                   onClick={e => this.props.onEdit && this.props.onEdit(e, this.props.name)}
                   >Edit</Link>
               </p>


### PR DESCRIPTION
We were targetting too many things with css when hiding edit links. added edit-link classname to edit link, only hide these