### PR TITLE
Bugfix - continued use reuse

### DIFF
--- a/client/pages/sections/granted/protocol-continued.js
+++ b/client/pages/sections/granted/protocol-continued.js
@@ -12,6 +12,11 @@ const Continued = ({ values, schemaVersion, pdf, title }) => {
         pdf && <h2>{ title }</h2>
       }
       {
+        (values.speciesDetails || []).length === 0 && (
+          <p>No animal types have been added to this protocol.</p>
+        )
+      }
+      {
         (values.speciesDetails || []).map((s, i) => (
           <Fragment key={i}>
             <h2>{s.name}</h2>


### PR DESCRIPTION
If there are no species in a granted licence, render a message instead