### PR TITLE
Handle null protocols when evaluating section display

### DIFF
--- a/client/schema/v1/index.js
+++ b/client/schema/v1/index.js
@@ -2314,7 +2314,7 @@ each other.`,
       nmbas: {
         title: 'Neuromuscular blocking agents (NMBAs)',
         show: values => some(values.protocols, protocol => {
-          return some(protocol.steps, step => step.nmbas);
+          return protocol && some(protocol.steps, step => step.nmbas);
         }),
         linkTo: 'protocols',
         steps: [
@@ -2369,7 +2369,7 @@ each other.`,
       },
       'reusing-animals': {
         title: 'Re-using animals',
-        show: project => some(project.protocols, protocol => some(protocol.speciesDetails, species => (species || {}).reuse)),
+        show: project => some(project.protocols, protocol => protocol && some(protocol.speciesDetails, species => (species || {}).reuse)),
         intro: 'You are seeing this section because you will be re-using animals during your project. If this is not correct, you can change this in Protocols.',
         fields: [
           {


### PR DESCRIPTION
Some licences in prod have ended up with a protocols value of `[null]` which causes this code to break.

Check the protocol exists before reading it.