### PR TITLE
Strip any chars disallowed by the xml spec

### DIFF
--- a/client/components/download-link/renderers/docx-renderer.js
+++ b/client/components/download-link/renderers/docx-renderer.js
@@ -9,6 +9,9 @@ import SPECIES from '../../../constants/species';
 import { getLegacySpeciesLabel, mapSpecies } from '../../../helpers';
 import { filterSpeciesByActive } from '../../../pages/sections/protocols/animals';
 
+/* eslint-disable no-control-regex */
+const stripInvalidXmlChars = text => text.replace(/([^\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFC\u{10000}-\u{10FFFF}])/ug, '');
+
 export default (application, sections, values, updateImageDimensions) => {
   const numbering = new Numbering();
   const abstract = numbering.createAbstractNumbering();
@@ -299,7 +302,7 @@ export default (application, sections, values, updateImageDimensions) => {
         node.nodes.forEach(childNode => {
           const leaves = childNode.leaves || [childNode];
           leaves.forEach(leaf => {
-            text = new TextRun(leaf.text);
+            text = new TextRun(stripInvalidXmlChars(leaf.text));
             if (text) {
               (leaf.marks || []).forEach(mark => {
                 switch (mark.type) {
@@ -485,7 +488,7 @@ export default (application, sections, values, updateImageDimensions) => {
         ? doc.createParagraph('Yes').style('body')
         : doc.createParagraph('No').style('body');
     } else {
-      doc.createParagraph(value).style('body');
+      doc.createParagraph(stripInvalidXmlChars(value)).style('body');
     }
 
     if (!noSeparator) {


### PR DESCRIPTION
Regex taken from https://www.ryadel.com/en/javascript-remove-xml-invalid-chars-characters-string-utf8-unicode-regex/ (ES6 version)