### PR TITLE
Fix sticky nav

### DIFF
--- a/client/components/side-nav.js
+++ b/client/components/side-nav.js
@@ -18,6 +18,9 @@ const SideNav = ({ schemaVersion, project, isGranted, ...props }) => {
     if (!isGranted) {
       return () => null;
     }
+
+    nav.current.style.position = 'relative';
+
     const pos = nav.current.offsetTop;
     const width = nav.current.offsetWidth;
     window.onscroll = () => {


### PR DESCRIPTION
Set to position relative again on page change (useEffect) as the positions dont get revaluated until scrolling