### PR TITLE
Ignore falsy values when traversing image dimensions

### DIFF
--- a/client/components/download-link/renderers/docx-renderer.js
+++ b/client/components/download-link/renderers/docx-renderer.js
@@ -747,7 +747,7 @@ export default (application, sections, values, updateImageDimensions) => {
   };
 
   const traverse = (obj, fn) => {
-    if (typeof obj !== 'object') {
+    if (!obj || typeof obj !== 'object') {
       return Promise.resolve(obj);
     }
 


### PR DESCRIPTION
The prod logs have this line throwing an error in certain circumstances. Ensure that the Word download doesn't break when arrays contain falsy values.