### PR TITLE
Check values are strings before running replace in Word renderer

### DIFF
--- a/client/components/download-link/renderers/docx-renderer.js
+++ b/client/components/download-link/renderers/docx-renderer.js
@@ -6,11 +6,8 @@ import get from 'lodash/get';
 import pickBy from 'lodash/pickBy';
 import mapValues from 'lodash/mapValues';
 import SPECIES from '../../../constants/species';
-import { getLegacySpeciesLabel, mapSpecies } from '../../../helpers';
+import { getLegacySpeciesLabel, mapSpecies, stripInvalidXmlChars } from '../../../helpers';
 import { filterSpeciesByActive } from '../../../pages/sections/protocols/animals';
-
-/* eslint-disable no-control-regex */
-const stripInvalidXmlChars = text => text.replace(/([^\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFC\u{10000}-\u{10FFFF}])/ug, '');
 
 export default (application, sections, values, updateImageDimensions) => {
   const numbering = new Numbering();

--- a/client/helpers/index.js
+++ b/client/helpers/index.js
@@ -119,3 +119,11 @@ export const flattenReveals = (fields, values) => {
     ])
   }, []);
 };
+
+/* eslint-disable no-control-regex */
+export const stripInvalidXmlChars = text => {
+  if (typeof text !== 'string') {
+    return text;
+  }
+  return text.replace(/([^\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFC\u{10000}-\u{10FFFF}])/ug, '')
+};


### PR DESCRIPTION
If a value is not a string then `replace` fails with an error. Check that values are string values before stripping XML.