### PR TITLE
Bugfix - don't call .include on undefined

### DIFF
--- a/client/components/review-field.js
+++ b/client/components/review-field.js
@@ -84,7 +84,7 @@ class ReviewField extends React.Component {
           <ul>
             {
               options
-                .filter(o => value.includes(o.value) || hasChildren(o))
+                .filter(o => (value || []).includes(o.value) || hasChildren(o))
                 .map((o, i) => (
                   <Fragment key={i}>
                     <li>{o.label}</li>


### PR DESCRIPTION
* Throws in review mode if permissible purposes was previously null