### PR TITLE
Don't show an error if redirecting a project edit

### DIFF
--- a/client/actions/messaging.js
+++ b/client/actions/messaging.js
@@ -30,7 +30,7 @@ export default function sendMessage({ method, data, url }) {
       // detect if redirect was attempted
       if (response.type === 'opaqueredirect') {
         window.onbeforeunload = null;
-        window.location.reload();
+        return window.location.reload();
       }
       return response.json()
         .then(json => {


### PR DESCRIPTION
If a user is trying to save a project with no session or editing an invalid project then don't show an error message when redirecting them.