### PR TITLE
Only repeat repeating fields

### DIFF
--- a/client/components/download-link/renderers/docx-renderer.js
+++ b/client/components/download-link/renderers/docx-renderer.js
@@ -635,7 +635,7 @@ export default (application, sections, values, updateImageDimensions) => {
           if (step.singular) {
             doc.createParagraph(`${step.singular} ${index + 1}`).heading2();
           }
-          (step.fields || []).forEach(field => renderField(doc, field, v, project));
+          (step.fields || []).filter(f => f.repeats).forEach(field => renderField(doc, field, v, project));
         });
         (step.fields || []).filter(f => !f.repeats).forEach(field => renderField(doc, field, values, project));
       } else {


### PR DESCRIPTION
Where a section contains repeating and non-repeating fields then _all_ fields are included in the repeater, and then the  non-repeating ones are rendered again.

Add a filter to the repeating section to only include repeated fields when looping over the values.