### PR TITLE
Return "Loading" message early from diff window if no before state

### DIFF
--- a/client/components/diff-window.js
+++ b/client/components/diff-window.js
@@ -243,16 +243,6 @@ class DiffWindow extends React.Component {
   }
 
   compare() {
-    const { previous, granted, changedFromLatest, changedFromGranted } = this.props;
-
-    let before = changedFromGranted ? granted : previous;
-
-    if (changedFromLatest && changedFromGranted) {
-      before = this.state.active === 0 ? granted : previous;
-    }
-
-    const changes = this.diff(before, this.props.value);
-    const hasContentChanges = this.hasContentChanges(before, this.props.value, this.props.type);
 
     if (this.props.loading) {
       return <div className="govuk-grid-row">
@@ -263,6 +253,17 @@ class DiffWindow extends React.Component {
         </div>
       </div>
     }
+
+    const { previous, granted, changedFromLatest, changedFromGranted } = this.props;
+
+    let before = changedFromGranted ? granted : previous;
+
+    if (changedFromLatest && changedFromGranted) {
+      before = this.state.active === 0 ? granted : previous;
+    }
+
+    const changes = this.diff(before, this.props.value);
+    const hasContentChanges = this.hasContentChanges(before, this.props.value, this.props.type);
 
     return <Fragment>
       {


### PR DESCRIPTION
The diff window's loading state was rendering _super_ slowly for large answers even before the "before" state had been fetched because even in the loading state it performs a `diff` between `undefined` and the current state, which is apparently still a fairly expensive operation.

Move the return of the loading message to above the `diff` call so if no "before" state is available then no computation is carried out.