### PR TITLE
Allow PPLs to be held by establishments without a PEL holder

### DIFF
--- a/client/pages/sections/granted/project-summary.js
+++ b/client/pages/sections/granted/project-summary.js
@@ -22,10 +22,7 @@ const ProjectSummary = ({
     name,
     licenceNumber,
     address,
-    licenceHolder: {
-      firstName,
-      lastName
-    }
+    licenceHolder
   },
   fields,
   pdf
@@ -92,7 +89,7 @@ const ProjectSummary = ({
             <dt>Establishment licence number: </dt>
             <dd>{ licenceNumber }</dd>
             <dt>Establishment licence holder: </dt>
-            <dd>{firstName} {lastName}</dd>
+            <dd>{ licenceHolder ? `${licenceHolder.firstName} ${licenceHolder.lastName}` : '-' }</dd>
             <dt>Address: </dt>
             <dd>{ address }</dd>
           </dl>


### PR DESCRIPTION
Currently if the establishment has no PEL holder then an error is thrown about trying to destruture their name.

If no PEL holder exists then render a `-` instead.