### PR TITLE
Pass correct id to changed indicator

### DIFF
--- a/client/pages/sections/protocols/steps.js
+++ b/client/pages/sections/protocols/steps.js
@@ -88,7 +88,7 @@ class Step extends Component {
         className={classnames('step', { completed, editable })}
         ref={this.step}
       >
-        <ChangedBadge fields={[ prefix.substr(0, prefix.length - 1) ]} protocolId={values.id} />
+        <ChangedBadge fields={[ prefix.substr(0, prefix.length - 1) ]} protocolId={protocol.id} />
         <Fragment>
           {
             editable && completed && !deleted && (


### PR DESCRIPTION
The `protocolId` prop should be the id of the protocol. Previously it was the id of the step.