### PR TITLE
Update labels on protocol speciesDetails when label changes in precoded species

### DIFF
--- a/client/pages/sections/protocols/animals.js
+++ b/client/pages/sections/protocols/animals.js
@@ -136,6 +136,12 @@ class Animals extends Component {
       if (precodedSpecies) {
         value = precodedSpecies.value;
         item = precodedSpecies.label
+        const matchingValue = speciesDetails.find(sd => sd.value === value);
+        // item is already in list - make sure it has the right label
+        if (matchingValue) {
+          matchingValue.name = item;
+          return;
+        }
       }
 
       if (some(speciesDetails, sd => sd.name === item)) {


### PR DESCRIPTION
If the label changes in the species selector then a second speciesDetails with the same value is added.

Ensure that the existing entry is used with an updated label instead of a new entry being added.