### PR TITLE
Flush protocol locations and objectives when top-level values change

### DIFF
--- a/client/actions/projects.js
+++ b/client/actions/projects.js
@@ -87,6 +87,14 @@ export function addChange(change) {
   }
 }
 
+export function addChanges(changes = {}) {
+  return {
+    type: types.ADD_CHANGES,
+    granted: changes.granted || [],
+    latest: changes.latest || []
+  }
+}
+
 export function updateSavedProject(project) {
   return {
     type: types.UPDATE_SAVED_PROJECT,
@@ -279,7 +287,8 @@ const syncProject = (dispatch, getState) => {
   return Promise.resolve()
     .then(() => dispatch(updateProject(project)))
     .then(() => sendMessage(params))
-    .then(() => {
+    .then(json => {
+      dispatch(addChanges(json.changes))
       dispatch(doneSyncing())
       if (state.application.syncError) {
         dispatch(syncErrorResolved());

--- a/client/actions/projects.js
+++ b/client/actions/projects.js
@@ -10,6 +10,7 @@ import database from '../database';
 import { showMessage, throwError } from './messages';
 import sendMessage from './messaging';
 import { getConditions } from '../helpers';
+import cleanProtocols from '../helpers/clean-protocols';
 
 const CONDITIONS_FIELDS = ['conditions', 'retrospectiveAssessment'];
 
@@ -364,8 +365,8 @@ const debouncedSyncProject = debounce((...args) => {
 
 export const ajaxSync = props => {
   return (dispatch, getState) => {
-    const { project } = getState();
-    const newState = { ...project, ...props };
+    const { project, application: { establishment } } = getState();
+    const newState = cleanProtocols(project, props, establishment);
 
     dispatch(updateProject(newState));
     return debouncedSyncProject(dispatch, getState);

--- a/client/actions/types.js
+++ b/client/actions/types.js
@@ -23,6 +23,7 @@ export const COMMENT_DELETED = 'COMMENT_DELETED';
 export const REFRESH_COMMENTS = 'REFRESH_COMMENTS';
 
 export const ADD_CHANGE = 'ADD_CHANGE';
+export const ADD_CHANGES = 'ADD_CHANGES';
 export const LOAD_QUESTION_VERSIONS = 'LOAD_QUESTION_VERSIONS';
 export const ERROR = 'ERROR';
 

--- a/client/components/application-summary.js
+++ b/client/components/application-summary.js
@@ -105,19 +105,30 @@ class ApplicationSummary extends React.Component {
     return !section.show || section.show(this.props.values);
   }
 
-  getComments = (key, subsection) => {
-    let newComments = 0;
+  getCommentCount = (key, subsection) => {
 
     if (subsection.repeats) {
-      newComments += flatten(Object.keys(this.props.newComments)
+      return flatten(Object.keys(this.props.newComments)
         .filter(key => key.match(new RegExp(`^${subsection.repeats}\\.`)))
         .map(key => this.props.newComments[key])).length;
+    } else {
+      return (this.props.fieldsBySection[key] || []).reduce((total, field) => {
+        if (field.includes('.*')) {
+          const prefix = field.split('.*')[0];
+          return total + Object.keys(this.props.newComments).reduce((sum, q) => {
+            if (q.split('.')[0] === prefix) {
+              return sum + this.props.newComments[q].length;
+            }
+            return sum;
+          }, 0);
+        }
+        return total + (this.props.newComments[field] || []).length
+      }, 0);
     }
+  }
 
-    newComments += (this.props.fieldsBySection[key] || []).reduce((total, field) => {
-      return total + (this.props.newComments[field] || []).length
-    }, 0);
-
+  getComments = (key, subsection) => {
+    const newComments = this.getCommentCount(key, subsection);
     return <NewComments comments={newComments} />
   }
 

--- a/client/components/application-summary.js
+++ b/client/components/application-summary.js
@@ -152,7 +152,7 @@ class ApplicationSummary extends React.Component {
                   subsections.map(key => {
                     const subsection = section.subsections[key];
                     const fields = Object.values(this.props.fieldsBySection[key] || []);
-                    if(subsection.repeats) {
+                    if (subsection.repeats) {
                       fields.push(subsection.repeats);
                     }
                     return <tr key={key}>

--- a/client/components/changed-badge.js
+++ b/client/components/changed-badge.js
@@ -20,7 +20,14 @@ export default function ChangedBadge({ fields = [], changedFromGranted, changedF
   if (!latest.length && !granted.length) {
     return null;
   }
-  const changedFrom = source => source.length && fields.some(field => source.some(change => change === field));
+  const changedFrom = source => {
+    return source.length && fields.some(field => {
+      if (field.includes('*')) {
+        field = field.split('.*')[0];
+      }
+      return source.some(change => change === field)
+    });
+  }
 
   if ((changedFromLatest || changedFrom(latest)) && (!protocolId || previousProtocols.previous.includes(protocolId))) {
     return <span className="badge changed">{ noLabel ? '' : 'changed' }</span>;

--- a/client/components/location-selector.js
+++ b/client/components/location-selector.js
@@ -3,11 +3,10 @@ import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 
 import Field from './field';
+import getLocations from '../helpers/get-locations';
 
 const LocationSelector = ({
-  establishment,
-  establishments,
-  poles,
+  locations,
   ...props
 }) => (
   <div className="location-selector">
@@ -15,11 +14,7 @@ const LocationSelector = ({
       {...props}
       type="checkbox"
       className="smaller"
-      options={[
-        ...(establishment ? [establishment.name] : []),
-        ...establishments,
-        ...poles
-      ]}
+      options={locations}
       noComments={true}
     />
     <Link to="../establishments">Add new establishment</Link>
@@ -28,9 +23,7 @@ const LocationSelector = ({
 )
 
 const mapStateToProps = ({ project, application: { establishment } }) => ({
-  establishment,
-  establishments: (project.establishments || []).filter(e => e['establishment-name']).map(e => e['establishment-name']),
-  poles: (project.polesList || []).filter(p => p.title).map(p => p.title)
+  locations: getLocations(project, establishment)
 });
 
 export default connect(mapStateToProps)(LocationSelector);

--- a/client/helpers/clean-protocols.js
+++ b/client/helpers/clean-protocols.js
@@ -1,0 +1,20 @@
+import intersection from 'lodash/intersection';
+import getLocations from './get-locations';
+
+export default function cleanProtocols (state, props, establishment) {
+  const project = { ...state, ...props };
+
+  if (!props.objectives && !props.establishments && !props.polesList) {
+    return project;
+  }
+
+  const locations = getLocations(project, establishment);
+  const objectives = project.objectives.map(o => o.title);
+
+  project.protocols = project.protocols || [];
+  project.protocols.forEach(protocol => {
+    protocol.objectives = intersection(protocol.objectives, objectives);
+    protocol.locations = intersection(protocol.locations, locations);
+  });
+  return project;
+}

--- a/client/helpers/get-locations.js
+++ b/client/helpers/get-locations.js
@@ -1,0 +1,9 @@
+export default function getLocations (project, establishment) {
+  const establishments = (project.establishments || []).filter(e => e['establishment-name']).map(e => e['establishment-name']);
+  const poles = (project.polesList || []).filter(p => p.title).map(p => p.title);
+  return [
+    establishment.name,
+    ...establishments,
+    ...poles
+  ];
+}

--- a/client/helpers/index.js
+++ b/client/helpers/index.js
@@ -121,11 +121,19 @@ export const flattenReveals = (fields, values) => {
 };
 
 export function getFields(section) {
-  if (!section.repeats && section.fields && section.fields.length) {
-    return section.fields;
+  if (section.fields && section.fields.length) {
+    return section.fields.map(field => {
+      if (field.repeats) {
+        return {
+          ...field,
+          name: `${section.repeats}.*.${field.name}`
+        };
+      }
+      return field;
+    });
   }
   else if (section.steps) {
-    return flatten(section.steps.filter(s => !s.repeats).map(step => step.fields));
+    return flatten(section.steps.map(getFields));
   }
   else return [];
 }

--- a/client/reducers/changes.js
+++ b/client/reducers/changes.js
@@ -6,7 +6,7 @@ const INITIAL_STATE = {
 };
 
 const changedItems = (state = [], action) => {
-  const paths = action.change.split('.').map((_, i, arr) => arr.slice(0, i + 1).join('.'));
+  const paths = action.split('.').map((_, i, arr) => arr.slice(0, i + 1).join('.'));
 
   return paths.reduce((arr, path) => {
     return arr.includes(path) ? arr : [ ...arr, path ];
@@ -18,7 +18,17 @@ const changes = (state = INITIAL_STATE, action) => {
     case types.ADD_CHANGE: {
       return {
         ...state,
-        latest: changedItems(state.latest, action)
+        latest: changedItems(state.latest, action.change)
+      };
+    }
+
+    case types.ADD_CHANGES: {
+      const granted = action.granted.reduce((arr, item) => changedItems(arr, item), state.granted);
+      const latest = action.latest.reduce((arr, item) => changedItems(arr, item), state.latest);
+      return {
+        ...state,
+        granted,
+        latest
       };
     }
   }


### PR DESCRIPTION
If an objective or location at the top level of a project is changed or removed then remove any obselete values from the objectives and locations on the protocols.

Includes a bit of a refactor of comment counts and updated flags to better understand repeated fields.