### PR TITLE
Don't scroll to top on hash changes

### DIFF
--- a/client/components/scroll-to-top.js
+++ b/client/components/scroll-to-top.js
@@ -7,7 +7,7 @@ const ScrollToTop = ({ children, location }) => {
     const header = document.querySelector('.download-header');
     const top = header ? header.offsetTop : 0;
     window.scrollTo(0, top);
-  }, [location]);
+  }, [location.pathname]);
 
   return children;
 }


### PR DESCRIPTION
Make the scroll to top handler more specific so that it doesn't respond to hash links, only to changes in the pathname