### PR TITLE
Handle special cases in Review component

### DIFF
--- a/client/components/review-field.js
+++ b/client/components/review-field.js
@@ -56,18 +56,6 @@ class ReviewField extends React.Component {
       )
     }
 
-    // we only want to render this component if viewing a granted licence, if not then fallback to default radio behaviour
-    if ((this.props.legacyGranted || this.props.isGranted) && (this.props.name === 'continuation' && !isUndefined(value)))  {
-      return (
-        <dl className="inline">
-          <dt>From the licence</dt>
-          <dd>{this.props.project['continuation-licence-number']}</dd>
-          <dt>Expiring on</dt>
-          <dd>{this.props.project['continuation-expiry-date'] && formatDate(this.props.project['continuation-expiry-date'], DATE_FORMAT.long)}</dd>
-        </dl>
-      );
-    }
-
     if (value && this.props.type === 'holder') {
       return (
         <Link page="profile.read" profileId={value.licenceHolder.id} establishmentId={value.establishment.id} label={`${value.licenceHolder.firstName} ${value.licenceHolder.lastName}`} />
@@ -233,12 +221,10 @@ class ReviewField extends React.Component {
 
 }
 
-const mapStateToProps = ({ project, settings, application: { isGranted, legacyGranted } }) => {
+const mapStateToProps = ({ project, settings }) => {
   return {
     project,
-    settings,
-    isGranted,
-    legacyGranted
+    settings
   };
 }
 

--- a/client/components/review.js
+++ b/client/components/review.js
@@ -12,7 +12,7 @@ import ErrorBoundary from './error-boundary';
 class Review extends React.Component {
 
   replay() {
-    return <ReviewField {...this.props} />;
+    return this.props.children || <ReviewField {...this.props} />;
   }
 
   render() {

--- a/client/pages/sections/legacy-introduction-review.js
+++ b/client/pages/sections/legacy-introduction-review.js
@@ -50,7 +50,14 @@ const LegacyIntroduction = ({ fields, project, values, pdf, readonly, title }) =
           label={continuationField.grantedLabel}
           value={values.continuation}
           values={values}
-        />
+        >
+          <dl className="inline">
+            <dt>From the licence</dt>
+            <dd>{values['continuation-licence-number']}</dd>
+            <dt>Expiring on</dt>
+            <dd>{values['continuation-expiry-date'] && formatDate(values['continuation-expiry-date'], DATE_FORMAT.long)}</dd>
+          </dl>
+        </Review>
       )
     }
       {readonly && !pdf && (


### PR DESCRIPTION
Allow implementations of the Review component to pass children in to override the default ReviewField behaviour to replay values. This allows special case renderings to be handled as one-off implementations rather than bundling everything into the Review component.

Implement this for project continuation on legacy licences.