### PR TITLE
Always display "Add another" step button when editing

### DIFF
--- a/assets/scss/projects.scss
+++ b/assets/scss/projects.scss
@@ -770,7 +770,9 @@ html.modal-open, html.modal-open body {
           }
         }
       }
-
+      &.editable .control-panel {
+        margin-top: 0;
+      }
       &.editable > .review .review a.edit-link {
         display: none;
       }

--- a/client/pages/sections/protocols/steps.js
+++ b/client/pages/sections/protocols/steps.js
@@ -4,7 +4,6 @@ import { useParams } from 'react-router';
 import classnames from 'classnames'
 import { Button } from '@ukhomeoffice/react-components';
 
-import every from 'lodash/every';
 import isUndefined from 'lodash/isUndefined';
 
 import ReviewFields from '../../../components/review-fields';
@@ -168,7 +167,7 @@ export default function Steps({ values, prefix, updateItem, editable, ...props }
         prefix={prefix}
         items={values.steps}
         onSave={steps => updateItem({ steps })}
-        addAnother={!values.deleted && every(values.steps, step => step.completed) && editable}
+        addAnother={!values.deleted && editable}
         { ...props }
       >
         <Step

--- a/client/pages/sections/protocols/steps.js
+++ b/client/pages/sections/protocols/steps.js
@@ -131,10 +131,12 @@ class Step extends Component {
                 onFieldChange={(key, value) => updateItem({ [key]: value })}
                 values={values}
               />
-              <Button onClick={this.saveStep}>Save step</Button>
-              {
-                length > 1 && <Button className="link" onClick={this.removeItem}>Remove step</Button>
-              }
+              <p className="control-panel">
+                <Button onClick={this.saveStep}>Save step</Button>
+                {
+                  length > 1 && <Button className="link" onClick={this.removeItem}>Remove step</Button>
+                }
+              </p>
             </Fragment>
           : <div className="review">
             <ReviewFields


### PR DESCRIPTION
Previously it was hidden in the case where some steps were in edit mode, but this was confusing for users who thought it was broken because they couldn't add more steps.

~WIP pending confirmation that we actually want to do this.~