### PR TITLE
Don't render null steps

### DIFF
--- a/client/pages/sections/protocols/steps.js
+++ b/client/pages/sections/protocols/steps.js
@@ -167,7 +167,7 @@ export default function Steps({ values, prefix, updateItem, editable, ...props }
         type="steps"
         singular="step"
         prefix={prefix}
-        items={values.steps}
+        items={values.steps.filter(Boolean)}
         onSave={steps => updateItem({ steps })}
         addAnother={!values.deleted && editable}
         { ...props }

--- a/client/schema/v1/index.js
+++ b/client/schema/v1/index.js
@@ -2243,7 +2243,7 @@ each other.`,
       nmbas: {
         title: 'Neuromuscular blocking agents (NMBAs)',
         show: values => some(values.protocols, protocol => {
-          return protocol && some(protocol.steps, step => step.nmbas);
+          return protocol && some(protocol.steps, step => step && step.nmbas);
         }),
         linkTo: 'protocols',
         steps: [


### PR DESCRIPTION
Not sure how some protocols have ended up having `null` in the steps array, but they do and it causes errors in rendering.

Handle those cases and allow the data to heal itself if it occurs.