### PR TITLE
Don't filter out deleted protocols when editing

### DIFF
--- a/client/pages/sections/protocols/protocols.js
+++ b/client/pages/sections/protocols/protocols.js
@@ -115,6 +115,9 @@ class Protocols extends PureComponent {
     const { protocols, editable, previousProtocols, isLegacy } = this.props;
 
     const items = (protocols || []).filter(p => {
+      if (editable) {
+        return true;
+      }
       if (p.deleted === true) {
         if (previousProtocols.showDeleted.includes(p.id)) {
           return true;


### PR DESCRIPTION
This results in the entire set of protocols being shown as part of the diff and massive PPL payloads.

Instead we'll let the client keep the list, and then filter deleted protocols from data at the point of granting.