### PR TITLE
Remove deleted protocols from PDF downloads

### DIFF
--- a/client/pages/sections/granted/pdf-protocols.js
+++ b/client/pages/sections/granted/pdf-protocols.js
@@ -112,7 +112,7 @@ const mapStateToProps = ({
   project,
   application: { schemaVersion }
 }) => ({
-  protocols: project.protocols,
+  protocols: (project.protocols || []).filter(protocol => !protocol.deleted),
   isLegacy: schemaVersion === 0,
   project
 });


### PR DESCRIPTION
Deleted protocols are being rendered into PDF downloads of draft licences. Filter these out before rendering.