### PR TITLE
Don't show transfer-related content on granted versions

### DIFF
--- a/client/components/establishment-selector.js
+++ b/client/components/establishment-selector.js
@@ -10,7 +10,21 @@ const revealContent = `To change the primary establishment you must:
 * review any related sections of the application that appear as ‘incomplete'`
 
 export default function EstablishmentSelector({ value, onFieldChange, review, diff, ...props }) {
-  const { establishments, canTransfer, establishment, transferInProgress, readonly, project } = useSelector(state => state.application, shallowEqual);
+  const {
+    establishments,
+    canTransfer,
+    establishment,
+    transferInProgress,
+    readonly,
+    project,
+    isGranted,
+    legacyGranted
+  } = useSelector(state => state.application, shallowEqual);
+
+  if (isGranted || legacyGranted) {
+    return <p>{establishment.name}</p>
+  }
+
   const [localValue, setLocalValue] = useState(value);
 
   const canUpdateEstablishment = canTransfer && establishments.length > 1 && !transferInProgress;

--- a/client/project-router.js
+++ b/client/project-router.js
@@ -14,9 +14,10 @@ const selector = ({
     isSyncing,
     basename,
     drafting,
-    isGranted
+    isGranted,
+    legacyGranted
   }
-}) => ({ project, version, isSyncing, basename, drafting, isGranted });
+}) => ({ project, version, isSyncing, basename, drafting, isGranted, legacyGranted });
 
 const ProjectRouter = () => {
   const [statusShowing, setStatusShowing] = useState(true);
@@ -26,7 +27,8 @@ const ProjectRouter = () => {
     isSyncing,
     basename,
     drafting,
-    isGranted
+    isGranted,
+    legacyGranted
   } = useSelector(selector, shallowEqual);
 
   function toggleStatusShowing() {
@@ -108,7 +110,7 @@ const ProjectRouter = () => {
           title={version.title || 'Untitled project'}
           subtitle="Project licence"
           basename={downloadBasename}
-          licenceStatus={ (project.status === 'active' && !isGranted) ? 'inactive' : project.status }
+          licenceStatus={ (project.status === 'active' && !(isGranted || legacyGranted)) ? 'inactive' : project.status }
           showAllDownloads={true}
         >
           <dl>


### PR DESCRIPTION
Skip all the logic about what content to display in what states, and if the licence is granted just return the basic content immediately.

~WIP because I still have some concerns about ASRU users reviewing not-transfers that I want to investigate.~