### PR TITLE
Hide comments on field type repeater

### DIFF
--- a/assets/scss/projects.scss
+++ b/assets/scss/projects.scss
@@ -1182,6 +1182,7 @@ html.modal-open, html.modal-open body {
   }
 
   .comments.expanding-panel {
+    margin-top: $govuk-gutter;
     margin-bottom: $govuk-gutter;
     border-top: 3px solid $govuk-border-colour;
     border-bottom: 3px solid $govuk-border-colour;

--- a/client/components/field.js
+++ b/client/components/field.js
@@ -276,11 +276,12 @@ const mapStateToProps = ({ project, settings, application }, { name, conditional
 const ConnectedField = connect(mapStateToProps, { addChange, throwError })(Field);
 
 const FieldGroup = props => {
+  const showComments = !props.noComments && props.type !== 'repeater';
   return (
     <Fragment>
       <ConnectedField {...props} />
       {
-        !props.noComments && <Comments field={props.name} />
+        showComments && <Comments field={props.name} />
       }
     </Fragment>
   )

--- a/client/components/review.js
+++ b/client/components/review.js
@@ -25,6 +25,8 @@ class Review extends React.Component {
       changedFromLatest,
       changedFromGranted
     } = this.props;
+    const showComments = !this.props.noComments && this.props.type !== 'repeater';
+
     return (
       <div className="review">
         {
@@ -56,7 +58,7 @@ class Review extends React.Component {
           this.replay()
         }
         {
-          !this.props.noComments && <Comments field={`${this.props.prefix || ''}${this.props.name}`} collapsed={!this.props.readonly} />
+          showComments && <Comments field={`${this.props.prefix || ''}${this.props.name}`} collapsed={!this.props.readonly} />
         }
         {
           // repeaters have edit links on the individual fields


### PR DESCRIPTION
The repeaters have comment UI on their children, so fields of `type: repeater` shoul not also render a comment UI.

Additionally add some top margin to the comment panel because it's overlapping with the preceding content in a really nasty way.