### PR TITLE
Bugfix - render reveal children

### DIFF
--- a/client/components/review-field.js
+++ b/client/components/review-field.js
@@ -171,7 +171,7 @@ class ReviewField extends React.Component {
                   getValue(value)
                 }
                 {
-                  this.props.preserveHierarchy && <RevealChildren value={value} options={options} {...this.props} />
+                  this.props.preserveHierarchy && <RevealChildren {...this.props} value={value} options={options} />
                 }
               </li>
             ))


### PR DESCRIPTION
* this.props was overwriting the value in this component, changed order to use single value