### PR TITLE
Refactor syncing

### DIFF
--- a/client/actions/projects.js
+++ b/client/actions/projects.js
@@ -256,6 +256,8 @@ function getProjectWithConditions(project) {
   };
 }
 
+const wait = t => new Promise(resolve => setTimeout(resolve, t));
+
 const syncProject = (dispatch, getState) => {
   const state = getState();
 
@@ -299,6 +301,7 @@ const syncProject = (dispatch, getState) => {
       const patched = applyPatches(state.savedProject, patch);
       dispatch(updateSavedProject(patched));
     })
+    .then(() => wait(2000))
     .then(() => syncProject(dispatch, getState))
     .catch(err => {
       onSyncError(syncProject, err, dispatch, getState)
@@ -370,7 +373,7 @@ export function fetchQuestionVersions(key) {
 
 const debouncedSyncProject = debounce((...args) => {
   return syncProject(...args);
-}, 1000, { maxWait: 5000, leading: true });
+}, 2000, { maxWait: 20000, leading: false });
 
 export const ajaxSync = props => {
   return (dispatch, getState) => {

--- a/client/components/editor/index.js
+++ b/client/components/editor/index.js
@@ -7,7 +7,6 @@ import { Markdown } from '@asl/components';
 
 import get from 'lodash/get';
 import defer from 'lodash/defer';
-import debounce from 'lodash/debounce';
 import isEqual from 'lodash/isEqual';
 
 import { throwError } from '../../actions/messages';
@@ -73,10 +72,10 @@ class TextEditor extends Component {
     this.editor = editor;
   };
 
-  save = debounce(() => {
+  save = () => {
     const { value } = this.state;
     this.props.onChange && this.props.onChange(serialiseValue(value));
-  }, 500, { maxWait: 5000, leading: true })
+  };
 
   onChange = ({ value }) => {
     const old = this.state.value;

--- a/client/project-router.js
+++ b/client/project-router.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { BrowserRouter, Route, Switch } from 'react-router-dom';
 import { useSelector, shallowEqual } from 'react-redux'
 import { DownloadHeader } from '@asl/components';
+import isEqual from 'lodash/isEqual';
 
 import ScrollToTop from './components/scroll-to-top';
 import Section from './pages/section';
@@ -10,15 +11,27 @@ import ProtocolSummary from './pages/sections/protocols/summary-table';
 
 const selector = ({
   project: version,
+  savedProject,
   application: {
+    readonly,
     project,
-    isSyncing,
     basename,
     drafting,
     isGranted,
     legacyGranted
   }
-}) => ({ project, version, isSyncing, basename, drafting, isGranted, legacyGranted });
+}) => {
+  const isSyncing = !readonly && !isEqual(version, savedProject);
+  return {
+    project,
+    version,
+    isSyncing,
+    basename,
+    drafting,
+    isGranted,
+    legacyGranted
+  };
+};
 
 const ProjectRouter = () => {
   const [statusShowing, setStatusShowing] = useState(true);


### PR DESCRIPTION
Use a comparison between the saved state and the local state to determine whether to use an `onbeforeunload` function instead of the `isSyncing` which only tracks if an http request is in progress, and is false if the sync is in a debounced state.

Increase the debounce limits on syncing to reduce the total number of syncs when an application is being actively worked on.