### PR TITLE
Check for differences in version state when editing conditions

### DIFF
--- a/client/project-router.js
+++ b/client/project-router.js
@@ -14,6 +14,7 @@ const selector = ({
   savedProject,
   application: {
     readonly,
+    editConditions,
     project,
     basename,
     drafting,
@@ -21,7 +22,9 @@ const selector = ({
     legacyGranted
   }
 }) => {
-  const isSyncing = !readonly && !isEqual(version, savedProject);
+  // only compare version data if version is in an editable state
+  const editable = !readonly || editConditions;
+  const isSyncing = editable && !isEqual(version, savedProject);
   return {
     project,
     version,


### PR DESCRIPTION
The early exit to avoid calculating version state when in readonly mode was causing `isSyncing` to be always false when editing conditions as an inspector. This meant that changes were not reliably saved.