### PR TITLE
Use throttle instead of debounce for keepalive

### DIFF
--- a/client/actions/session.js
+++ b/client/actions/session.js
@@ -1,7 +1,7 @@
-import debounce from 'lodash/debounce';
+import throttle from 'lodash/throttle';
 import sendMessage from './messaging';
 
-const debouncedSendMessage = debounce(sendMessage, 30000);
+const debouncedSendMessage = throttle(sendMessage, 30000);
 
 export const keepAlive = () => {
   return () => {


### PR DESCRIPTION
Throttle doesn't care if it keeps being called, it will still send a keepalive every 30 seconds. Debounce will _never_ send a keepalive if it keeps being called every 29 seconds. This means inspectors who remain entirely active will get timed out.