### PR TITLE
Move syncing tracking code out of router into separate component

### DIFF
--- a/client/components/sync-handler.js
+++ b/client/components/sync-handler.js
@@ -1,0 +1,61 @@
+import React, { useEffect } from 'react';
+import { useSelector, shallowEqual } from 'react-redux'
+import isEqual from 'lodash/isEqual';
+import classnames from 'classnames';
+
+const selector = ({
+  project: version,
+  savedProject,
+  application: {
+    readonly,
+    editConditions
+  }
+}) => {
+  // only compare version data if version is in an editable state
+  const editable = !readonly || editConditions;
+  const isSyncing = editable && !isEqual(version, savedProject);
+  return { isSyncing };
+};
+
+const SyncHandler = () => {
+
+  const { isSyncing } = useSelector(selector, shallowEqual);
+
+  useEffect(() => {
+    window.onbeforeunload = () => {
+      if (isSyncing) {
+        return true;
+      }
+    }
+
+    const nextSteps = document.querySelector('#page-component > p.next-steps > a');
+    const statusMessage = document.querySelector('#page-component > p.next-steps > span.status-message');
+
+    if (isSyncing) {
+      if (nextSteps) {
+        nextSteps.setAttribute('disabled', true);
+        nextSteps.onclick = () => false;
+      }
+      statusMessage && (statusMessage.innerText = 'Saving...');
+    } else {
+      if (nextSteps) {
+        nextSteps.removeAttribute('disabled');
+        nextSteps.onclick = null;
+      }
+      statusMessage && (statusMessage.innerText = '');
+    }
+
+    return () => {
+      window.onbeforeunload = null;
+      if (nextSteps) {
+        nextSteps.removeAttribute('disabled');
+        nextSteps.onclick = null;
+      }
+      statusMessage && (statusMessage.innerText = '');
+    }
+  })
+
+  return <div className={classnames('sync-indicator', { syncing: isSyncing })}></div>;
+};
+
+export default SyncHandler;


### PR DESCRIPTION
Renders an empty div to the page with some classes to indicate sync state to allow for easier tracking in functional tests, and potentially a starting point for future UI as well.