### PR TITLE
Send version as header to server

### DIFF
--- a/client/actions/messaging.js
+++ b/client/actions/messaging.js
@@ -1,4 +1,5 @@
 import fetch from 'r2';
+import { version } from '../../package.json';
 
 export function postError({ error, info }) {
   const params = {
@@ -23,6 +24,10 @@ export default function sendMessage({ method, data, url }) {
     // to keycloak if users session expires
     redirect: 'manual',
     json: data,
+    headers: {
+      // send version header for compatability validation on server
+      'x-projects-version': version
+    }
   };
   return Promise.resolve()
     .then(() => fetch(url, params).response)

--- a/client/actions/projects.js
+++ b/client/actions/projects.js
@@ -232,7 +232,10 @@ const onSyncError = (func, err, dispatch, getState, ...args) => {
   console.error(err);
   dispatch(doneSyncing());
   dispatch(syncError());
-  dispatch(throwError('Failed to save, trying again'));
+  dispatch(throwError(err.code === 'UPDATE_REQUIRED'
+    ? 'This software has been updated. You must refresh your browser to avoid losing work.'
+    : 'Failed to save, trying again'
+  ));
   return setTimeout(() => func(dispatch, getState, ...args), 1000);
 };
 


### PR DESCRIPTION
This allows the local and server versions to be validated for compatibility and incompatible old versions to be prompted to refresh.