### PR TITLE
Prevent error in PDF rendering legacy PPLs

### DIFF
--- a/client/pages/sections/protocols/sections.js
+++ b/client/pages/sections/protocols/sections.js
@@ -125,7 +125,7 @@ const ProtocolSections = ({ sections, protocolState, editable, newComments, ...p
   let sectionNames = Object.keys(sections)
     .filter(section => !sections[section].show || sections[section].show(props));
 
-  if (props.isGranted && !props.isFullApplication) {
+  if (props.isGranted && !props.isFullApplication && props.schemaVersion > 0) {
     sectionNames = sectionNames.sort(sortGranted(sections));
   }
   return (


### PR DESCRIPTION
Legacy PPLs are always the full application, and so need an extra condition here to prevent them trying to sort by a `granted` property that does not exist.