### PR TITLE
Handle errors in rich text rendering marginally more gracefully

### DIFF
--- a/client/components/download-link/renderers/docx-renderer.js
+++ b/client/components/download-link/renderers/docx-renderer.js
@@ -106,6 +106,13 @@ export default (application, sections, values, updateImageDimensions) => {
       .quickFormat()
       .font('Helvetica')
       .size(20);
+
+    document.Styles.createParagraphStyle('error', 'Error')
+      .basedOn('Body')
+      .next('Body')
+      .quickFormat()
+      .color('FF0000')
+      .bold();
   };
 
   const addPageNumbers = () => {
@@ -361,7 +368,14 @@ export default (application, sections, values, updateImageDimensions) => {
     }
     const nodes = content.document.nodes;
 
-    nodes.forEach(node => renderNode(doc, node));
+    nodes.forEach(node => {
+      try {
+        renderNode(doc, node);
+      } catch (e) {
+        doc.createParagraph(`There was a problem rendering this content (${node.type})`).style('error');
+        doc.createParagraph(e.stack).style('error');
+      }
+    });
 
     if (!noSeparator) {
       renderHorizontalRule(doc);


### PR DESCRIPTION
Instead of crashing the entire document, replace the failing node with an error block.

Input (with bold text set to throw an error)
![image](https://user-images.githubusercontent.com/117398/86228472-55570700-bb86-11ea-92f8-fdaf5f22b1e1.png)

Output
![image](https://user-images.githubusercontent.com/117398/86228618-80415b00-bb86-11ea-9dca-4cfc000d88ab.png)

