### PR TITLE
Use structured input for continued use on T&E licences

### DIFF
--- a/client/schema/v1/index.js
+++ b/client/schema/v1/index.js
@@ -759,19 +759,35 @@ If you can only add generic information at this stage, provide a general descrip
           },
           {
             name: 'transfer-expiring',
-            label: 'Do you need to transfer animals from an expiring licence as continued use?',
+            label: 'Do you need to transfer animals from a project that’s due to expire?',
             type: 'radio',
             inline: true,
             className: 'smaller',
+            preserveHierarchy: true,
             options: [
               {
                 label: 'Yes',
                 value: true,
                 reveal: [
                   {
-                    name: 'expiring-yes',
-                    label: 'Please state the licence number and expiry date of all these licences.',
-                    type: 'texteditor'
+                    name: 'project-continuation',
+                    type: 'repeater',
+                    singular: 'Expiring project',
+                    addAnotherLabel: 'Transfer animals from another project',
+                    addAnotherClassName: 'link',
+                    fields: [
+                      {
+                        name: 'licence-number',
+                        type: 'text',
+                        label: 'Project licence number'
+                      },
+                      {
+                        name: 'expiry-date',
+                        type: 'date',
+                        label: 'Expiry date',
+                        hint: 'For example, 13 06 2019'
+                      }
+                    ]
                   }
                 ]
               },


### PR DESCRIPTION
This became misaligned because the T&E questions were added before continued use changed.