### PR TITLE
Filter questions in NTS summary

### DIFF
--- a/client/pages/sections/nts.js
+++ b/client/pages/sections/nts.js
@@ -87,7 +87,9 @@ class NTSSummary extends Component {
     if (section.steps){
       fields = flatten(section.steps.map((step, index) => step.fields.map(field => ({ ...field, step: index }))));
     }
-    return fields.filter(field => !whitelist || whitelist.includes(field.name));
+    return fields
+      .filter(field => !whitelist || whitelist.includes(field.name))
+      .filter(field => !field.show || field.show(this.props.project));
   }
 
   onCompleteChange = complete => {


### PR DESCRIPTION
The `show` property of fields was not being used when getting the list of fields to show in the NTS review section.

This means it was showing all of the fields, both for training licences and non-training licences.