### PR TITLE
Don't render hidden fields into word output

### DIFF
--- a/client/components/download-link/renderers/docx-renderer.js
+++ b/client/components/download-link/renderers/docx-renderer.js
@@ -606,6 +606,9 @@ export default (application, sections, values, updateImageDimensions) => {
   };
 
   const renderField = (doc, field, values, project, noSeparator) => {
+    if (field.show && !field.show(values)) {
+      return false;
+    }
     project = project || values;
     const value = values[field.name];
 


### PR DESCRIPTION
Questions that are not asked because they're conditional on other fields should not be rendered into the Word download.