### PR TITLE
Don't render empty paragraphs into rich text editors

### DIFF
--- a/client/components/download-link/renderers/docx-renderer.js
+++ b/client/components/download-link/renderers/docx-renderer.js
@@ -299,6 +299,9 @@ export default (application, sections, values, updateImageDimensions) => {
 
       case 'paragraph':
       case 'block':
+        if (node.nodes.length === 1 && !getContent(node)) {
+          return;
+        }
         addToDoc = !paragraph;
         paragraph = paragraph || new Paragraph();
         node.nodes.forEach((childNode, childNodeIndex) => {


### PR DESCRIPTION
Some rich text input ends up with empty paragraphs between actual paragraphs, which results in masses of whitespace when rendered into word. Don't include any completely empty paragraphs.