### PR TITLE
Prevent transfer message showing in review mode

### DIFF
--- a/client/components/establishment-selector.js
+++ b/client/components/establishment-selector.js
@@ -22,7 +22,7 @@ export default function EstablishmentSelector({ value, onFieldChange, review, di
     legacyGranted
   } = useSelector(state => state.application, shallowEqual);
 
-  if (isGranted || legacyGranted) {
+  if (isGranted || legacyGranted || review) {
     return <p>{establishment.name}</p>
   }
 
@@ -78,7 +78,7 @@ export default function EstablishmentSelector({ value, onFieldChange, review, di
   return (
     <div className="establishment-selector">
       {
-        canUpdateEstablishment && !review
+        canUpdateEstablishment
           ? (
             <RadioGroup
               {...props}
@@ -119,7 +119,7 @@ export default function EstablishmentSelector({ value, onFieldChange, review, di
           )
       }
       {
-        canTransfer && !review && (
+        canTransfer && (
           <Details summary="Why is the establishment I'm looking for not listed?">
             <Inset>
               <p>If the establishment is not listed, ask the Home Office Liaison Contact (HOLC) of that establishment to send you an invitation. Once you accept the invitation, you can request your licence to be transferred.</p>

--- a/client/pages/sections/establishments.js
+++ b/client/pages/sections/establishments.js
@@ -2,22 +2,18 @@ import React, { Fragment } from 'react';
 import { connect } from 'react-redux';
 import RepeaterReview from './repeater/review';
 
-const Establishments = ({ establishment, isFullApplication, ...props }) => {
+const Establishments = ({ isFullApplication, ...props }) => {
   return (
     <Fragment>
       {
         isFullApplication && <h2>Establishments</h2>
       }
-      <div className="review">
-        <h3>Primary establishment</h3>
-        <p>{ establishment.name }</p>
-      </div>
 
       <RepeaterReview {...props} />
     </Fragment>
   )
 }
 
-const mapStateToProps = ({ application: { establishment, isFullApplication } }) => ({ establishment, isFullApplication });
+const mapStateToProps = ({ application: { isFullApplication } }) => ({ isFullApplication });
 
 export default connect(mapStateToProps)(Establishments);


### PR DESCRIPTION
All PPL applications are showing a "transfer requested" message, even if they're first time applications. This is because the establishment selector component is now used in first-time applications as well as amendments, but did not have the internal logic updated to reflect this.

Return the simple establishment playback early in review, in the same way as for granted licences. Also remove the double playback of establishment from the establishments review section, so it only appears once.