### PR TITLE
Export non-connected instance of ReviewFields

### DIFF
--- a/client/components/review-fields.js
+++ b/client/components/review-fields.js
@@ -74,4 +74,5 @@ const ReviewFields = ({
 
 const mapStateToProps = ({ project, application }) => ({ project, application });
 
+export { ReviewFields };
 export default connect(mapStateToProps)(ReviewFields);


### PR DESCRIPTION
This is used in some contexts where the redux store does not exist - specifically in asl-pages for reviewing PPL holder changes.

In those cases we need to be able to pass the `project` prop in directly in order to render conditional fields correctly.