### PR TITLE
Remove double title on training page in readonly

### DIFF
--- a/client/pages/sections/training.js
+++ b/client/pages/sections/training.js
@@ -23,7 +23,9 @@ export default function Training(props) {
 
   return (
     <Fragment>
-      <h1>Training</h1>
+      {
+        !readonly && <h1>Training</h1>
+      }
       <p>{props.intro}</p>
       <h2>Training record</h2>
       <TrainingSummary certificates={readonly ? project.training : training} />


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/117398/90257776-82622f00-de3f-11ea-94c2-4edc4f9e640b.png)

After:
![image](https://user-images.githubusercontent.com/117398/90257802-88f0a680-de3f-11ea-98c9-f1f5ed541f4b.png)
