### PR TITLE
Confirm edit if protocols affected

### DIFF
--- a/client/components/fieldset.js
+++ b/client/components/fieldset.js
@@ -1,23 +1,39 @@
 import React from 'react';
 
+import ToggleEdit from './toggle-edit';
 import Field from './field';
 
 const Fieldset = ({ fields, onFieldChange, values, noComments, altLabels, prefix = '' }) => (
   <fieldset>
     {
-      fields.map(field => {
-        return <Field
-          { ...field }
-          key={ field.name }
-          name={ `${prefix}${field.name}` }
-          value={ values && values[field.name] }
+      fields.map(f => {
+        const field = <Field
+          { ...f }
+          key={ f.name }
+          name={ `${prefix}${f.name}` }
+          value={ values && values[f.name] }
           values={ values }
           prefix={ prefix }
-          onChange={ value => onFieldChange(field.name, value) }
+          onChange={ value => onFieldChange(f.name, value) }
           onFieldChange={onFieldChange}
           noComments={noComments}
           altLabels={altLabels}
-        />
+        />;
+
+        if (f.toggleEdit) {
+          return (
+            <ToggleEdit
+              label={f.label}
+              value={values && values[f.name]}
+              values={values}
+              confirmEdit={f.confirmEdit}
+            >
+              {field}
+            </ToggleEdit>
+          );
+        }
+
+        return field;
       })
     }
   </fieldset>

--- a/client/components/species-selector.js
+++ b/client/components/species-selector.js
@@ -8,7 +8,6 @@ import map from 'lodash/map';
 import intersection from 'lodash/intersection';
 import uniq from 'lodash/uniq';
 
-import confirmRemove from '../helpers/confirm-remove';
 import { projectSpecies as SPECIES } from '@asl/constants';
 import SPECIES_CATEGORIES from '../constants/species-categories';
 
@@ -62,7 +61,8 @@ class SpeciesSelector extends Component {
       label,
       onFieldChange,
       name,
-      hint
+      hint,
+      confirmRemove
     } = this.props;
 
     const deprecated = (vals[name] || [])
@@ -101,7 +101,7 @@ class SpeciesSelector extends Component {
                   value={vals[name]}
                   onChange={this.onGroupChange(code)}
                   onFieldChange={onFieldChange}
-                  confirmRemove={this.props.confirmRemove && confirmRemove('species', 'animal type')}
+                  confirmRemove={confirmRemove}
                   noComments={true}
                 />
               </details>

--- a/client/components/toggle-edit.js
+++ b/client/components/toggle-edit.js
@@ -1,0 +1,33 @@
+import React, { useState } from 'react';
+import { useSelector } from 'react-redux';
+import isFunction from 'lodash/isFunction';
+
+export default function ToggleEdit({ label, value, values, confirmEdit, children }) {
+
+  const [editable, setEditable] = useState(!value);
+  const project = useSelector(state => state.project);
+
+  function triggerEditable(e) {
+    e.preventDefault();
+    if (isFunction(confirmEdit)) {
+      if (confirmEdit(project, values)) {
+        return setEditable(true);
+      }
+      return;
+    }
+    return setEditable(true);
+  }
+
+  if (!editable) {
+    return (
+      <div className="toggle-edit">
+        <div className="govuk-form-group">
+          <label className="govuk-label">{label}</label>
+          <p>{value} <a href="#" onClick={triggerEditable}>{`Edit ${label.toLowerCase()}`}</a></p>
+        </div>
+      </div>
+    );
+  }
+
+  return <div className="toggle-edit">{children}</div>;
+}

--- a/client/helpers/confirm-protocols-affected.js
+++ b/client/helpers/confirm-protocols-affected.js
@@ -14,10 +14,11 @@ function getProtocolParts(protocols) {
   }).join('');
 }
 
-const confirmRemove = (protocolRef, singularName, key) => (project, item) => {
+const confirmProtocolsAffected = (changeType, protocolRef, singularName, key, label) => (project, item) => {
   const protocols = (project.protocols || [])
     .filter(p => !p.deleted)
     .map((protocol, index) => ({ ...protocol, index }));
+
   const affectedProtocols = protocols.filter(protocol => (protocol[protocolRef] || []).includes(key ? item[key] : item));
 
   // item doesn't appear in any protocols
@@ -25,7 +26,13 @@ const confirmRemove = (protocolRef, singularName, key) => (project, item) => {
     return true;
   }
 
-  let message = `Protocols will be affected\n\nRemoving this ${singularName} will also remove it from`;
+  let message = `Protocols will be affected\n\n`;
+
+  if (changeType === 'remove') {
+    message = `${message}Removing this ${singularName} will also remove it from`;
+  } else {
+    message = `${message}Changing the ${label || key} of this ${singularName} will remove it from`;
+  }
 
   // item appears in all protocols
   if (affectedProtocols.length === protocols.length) {
@@ -37,7 +44,8 @@ const confirmRemove = (protocolRef, singularName, key) => (project, item) => {
     ? `protocol ${affectedProtocols[0].index + 1}`
     // item appears in many protocols, list them
     : `protocols ${getProtocolParts(affectedProtocols)}`;
+
   return window.confirm(`${message} ${protocolText}.`);
 };
 
-export default confirmRemove;
+export default confirmProtocolsAffected;

--- a/client/schema/v1/index.js
+++ b/client/schema/v1/index.js
@@ -32,7 +32,7 @@ import some from 'lodash/some';
 import experience from './experience';
 import permissiblePurpose from './permissible-purpose';
 
-import confirmRemove from '../../helpers/confirm-remove';
+import confirmProtocolsAffected from '../../helpers/confirm-protocols-affected';
 
 import { isTrainingLicence } from '../../helpers';
 
@@ -114,7 +114,7 @@ export default () => ({
             name: 'species',
             label: 'Which types of animals will be used in this project?',
             type: 'species-selector',
-            confirmRemove: true,
+            confirmRemove: confirmProtocolsAffected('remove', 'species', 'animal type'),
             summary: true
           }
         ]
@@ -227,7 +227,7 @@ export default () => ({
             show: values => values['other-establishments'],
             repeats: 'establishments',
             singular: 'Additional establishment',
-            confirmRemove: confirmRemove('locations', 'establishment', 'establishment-name'),
+            confirmRemove: confirmProtocolsAffected('remove', 'locations', 'establishment', 'establishment-name'),
             fields: [
               {
                 name: 'establishment-name',
@@ -315,7 +315,7 @@ export default () => ({
             repeats: 'polesList',
             singular: 'POLE',
             show: values => values.poles === true,
-            confirmRemove: confirmRemove('locations', 'POLE', 'title'),
+            confirmRemove: confirmProtocolsAffected('remove', 'locations', 'POLE', 'title'),
             subtitle: 'Specify the details of each POLE that you will be using.',
             intro: `If you can’t specify a grid reference for a POLE, include details that allows it to be easily identified for inspection. This could be an address of a site or a postcode of a farm.
 
@@ -325,7 +325,9 @@ If you can only add generic information at this stage, provide a general descrip
                 name: 'title',
                 label: 'Name',
                 type: 'text',
-                repeats: true
+                repeats: true,
+                toggleEdit: true,
+                confirmEdit: confirmProtocolsAffected('edit', 'locations', 'POLE', 'title', 'name'),
               },
               {
                 name: 'pole-info',
@@ -840,7 +842,7 @@ If you can only add generic information at this stage, provide a general descrip
             singular: 'Objective',
             component: Objectives,
             repeats: 'objectives',
-            confirmRemove: confirmRemove('objectives', 'objective', 'title'),
+            confirmRemove: confirmProtocolsAffected('remove', 'objectives', 'objective', 'title'),
             fields: [
               {
                 name: 'title',
@@ -848,7 +850,9 @@ If you can only add generic information at this stage, provide a general descrip
                 review: 'Objective title',
                 type: 'text',
                 objective: true,
-                repeats: true
+                repeats: true,
+                toggleEdit: true,
+                confirmEdit: confirmProtocolsAffected('edit', 'objectives', 'objective', 'title'),
               },
               {
                 name: 'objective-relation',


### PR DESCRIPTION
Adds an edit toggle to the POLE name / Objective title fields that will trigger a warning message if any protocols will be affected by the change.