### PR TITLE
Accessibility - RTE image focus

### DIFF
--- a/assets/scss/_editor.scss
+++ b/assets/scss/_editor.scss
@@ -69,6 +69,11 @@
     box-shadow: 0 2px 0 #929191;
     overflow: hidden;
     position: relative;
+
+    &:focus-within {
+      @extend :focus;
+    }
+
     &:hover {
       background-color: $mid-grey;
     }

--- a/client/components/editor/format-toolbar.js
+++ b/client/components/editor/format-toolbar.js
@@ -40,6 +40,7 @@ class FormatToolbar extends Component {
           className={classnames('tooltip-icon-button', { active: isActive })}
           title={tooltip}
           aria-label={tooltip}
+          tabIndex={-1}
         >
           <input
             type='file'


### PR DESCRIPTION
* As an input is inside a button, both are focussed in order when tabbing - when the actual icon is highlighted you cannot interacti with it, only when the invisible child input is focussed. Removed tabIndex from parent, and added focus-within style