### PR TITLE
Use an actual hash of objects without ids for objectHash diff method

### DIFF
--- a/client/actions/projects.js
+++ b/client/actions/projects.js
@@ -10,10 +10,15 @@ import { showMessage, throwError } from './messages';
 import sendMessage from './messaging';
 import { getConditions } from '../helpers';
 import cleanProtocols from '../helpers/clean-protocols';
+import sha from 'sha.js';
 
 const CONDITIONS_FIELDS = ['conditions', 'retrospectiveAssessment'];
 
-const jsondiff = require('jsondiffpatch').create({ objectHash: obj => obj.id });
+const jsondiff = require('jsondiffpatch').create({
+  objectHash: obj => {
+    return obj.id || sha('sha256').update(obj).digest('hex');
+  }
+});
 
 export function loadProjects() {
   return dispatch => {

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "redux-logger": "^3.0.6",
     "redux-thunk": "^2.3.0",
     "regenerator-runtime": "^0.13.2",
+    "sha.js": "^2.4.11",
     "slate": "^0.47.8",
     "slate-hyperscript": "^0.13.4",
     "slate-react": "^0.22.4",


### PR DESCRIPTION
If the `objectHash` is undefined then jsondiffpatch uses strict equality to compare elements in arrays, which for text editors - which include a lot of arrays of objects - results in very large diffs for no changes.

If an object doesn't have an id property then use the actual sha256 hash of the object to determine its `objectHash` so that objects are effectively compared by value and not using strict equality.