### PR TITLE
Use diffSentences to compare long passages

### DIFF
--- a/client/components/diff-window.js
+++ b/client/components/diff-window.js
@@ -2,7 +2,7 @@ import React, { Fragment } from 'react';
 import { connect } from 'react-redux';
 import classnames from 'classnames';
 import { Value } from 'slate';
-import { diffWords, diffArrays } from 'diff';
+import { diffWords, diffSentences, diffArrays } from 'diff';
 import last from 'lodash/last';
 import { Warning } from '@ukhomeoffice/react-components';
 import { fetchQuestionVersions } from '../actions/projects';
@@ -92,8 +92,11 @@ class DiffWindow extends React.Component {
         } catch (e) {
           return { added: [], removed: [] };
         }
-
-        diffs = diffWords(before.document.text, after.document.text);
+        if (before.document.text.length < 5000 && after.document.text.length < 5000) {
+          diffs = diffWords(before.document.text, after.document.text);
+        } else {
+          diffs = diffSentences(before.document.text, after.document.text);
+        }
 
         removed = diffs.reduce((arr, d) => {
           // ignore additions


### PR DESCRIPTION
There is a PPL amendment in prod with a 4,500 word answer that contains a lot of changes. Trying to view the diff of that answer using `diffWords` causes the pages to crash.

Replacing `diffWords` with `diffSentences` for long passages vastly improves the performance of the component.