### PR TITLE
Fix step index when values are saved as objects

### DIFF
--- a/client/pages/sections/granted/protocol-steps.js
+++ b/client/pages/sections/granted/protocol-steps.js
@@ -47,7 +47,16 @@ const Steps = ({ values, fields, pdf, prefix }) => {
     if (!title) {
       return untitled;
     }
-    const value = Value.fromJSON(JSON.parse(title));
+
+    if (typeof title === 'string') {
+      try {
+        title = JSON.parse(title);
+      } catch (e) {
+        return untitled;
+      }
+    }
+
+    const value = Value.fromJSON(title);
     return value.document.text && value.document.text !== ''
       ? value.document.text
       : untitled;


### PR DESCRIPTION
Trying to `JSON.parse` the value of a rich text editor which is saved as an object throws an error because it's equivalent to `JSON.parse('[object Object]')`.

Instead only `JSON.parse` when the value is already a string.