### PR TITLE
Hard-code keywords output in granted PPL view

### DIFF
--- a/client/pages/sections/granted/project-summary.js
+++ b/client/pages/sections/granted/project-summary.js
@@ -80,6 +80,7 @@ const ProjectSummary = ({
               <Review
                 name="keywords"
                 label="Key words that describe this project"
+                type="keywords"
                 value={values.keywords}
                 noComments
               />
@@ -95,7 +96,9 @@ const ProjectSummary = ({
             </div>
             <div className="granted-section">
               <Review
-                {...fields.find(f => f.name === 'keywords')}
+                name="keywords"
+                label="Key words that describe this project"
+                type="keywords"
                 value={values.keywords}
                 noComments
               />


### PR DESCRIPTION
This was looking for the field data from the schema, but it's not there because it moved to the NTS section. Hard-code it for the digital view in the same way as it already was for PDFs.