### PR TITLE
Prevent Aims playback appearing twice in granted licence views

### DIFF
--- a/client/pages/sections/granted/action-plan.js
+++ b/client/pages/sections/granted/action-plan.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import Playback from '../../../components/playback'
 import ObjectivesReview from '../objectives/review';
 
 const ActionPlan = props => (
@@ -7,9 +6,6 @@ const ActionPlan = props => (
     {
       props.pdf && <h2>{props.title}</h2>
     }
-    <div className="granted-section">
-      <Playback playback="project-aim" />
-    </div>
     <ObjectivesReview {...props} />
   </div>
 )

--- a/client/pages/sections/objectives/review.js
+++ b/client/pages/sections/objectives/review.js
@@ -19,9 +19,7 @@ const ObjectivesReview = ({ playback, values, steps, goto, readonly, isFullAppli
         </Fragment>
       )
     }
-    {
-      <Playback playback={playback} />
-    }
+    <Playback playback={playback} />
     {
       isFullApplication && <h2>Action plan</h2>
     }


### PR DESCRIPTION
Aims playback is added in ObjectivesReview component as well as the ActionPlan granted view.

Remove it from the latter so it only appears once in granted licences.