### PR TITLE
Handle playback fields configured as arrays

### DIFF
--- a/client/pages/sections/review.js
+++ b/client/pages/sections/review.js
@@ -1,4 +1,5 @@
 import React, { Fragment } from 'react';
+import castArray from 'lodash/castArray';
 
 import ReviewFields from '../../components/review-fields';
 import Banner from '../../components/banner';
@@ -27,7 +28,7 @@ const ReviewSection = ({
         nts && <NTS review={true} />
       }
       {
-        playback && <Playback playback={playback} />
+        playback && castArray(playback).map(p => <Playback key={p} playback={p} />)
       }
       <ReviewFields fields={fields} values={values} onEdit={onEdit} />
     </Fragment>


### PR DESCRIPTION
The project introduction section of a legacy NTS has the `playback` property set to an array. This is handled in some places - e.g. https://github.com/UKHomeOffice/asl-projects/blob/3133f6f29d7e333a0159e20b882d11f8ab01f381/client/pages/sections/index.js#L73 - but was not handled correctly here resulting in an error rendering that section.