### PR TITLE
Handle case where `playback` on a section is a function

### DIFF
--- a/client/components/playback.js
+++ b/client/components/playback.js
@@ -43,6 +43,9 @@ const Playback = ({ project, step, history, field, section, readonly, basename, 
 
 const mapStateToProps = ({ application: { schemaVersion, readonly, basename }, project }, { playback }) => {
   playback = isFunction(playback) ? playback(project) : playback;
+  if (!playback) {
+    return null;
+  }
   let step;
   let field;
   const schema = schemaMap[schemaVersion];


### PR DESCRIPTION
In some cases - for example the Action Plan section on a training licence - the `playback` property of a section is a function that returns null or undefined when no playback is required.

Handle these cases correctly in the playback component.