### PR TITLE
Display error alert in front of sticky header

### DIFF
--- a/assets/scss/projects.scss
+++ b/assets/scss/projects.scss
@@ -496,7 +496,7 @@ html.modal-open, html.modal-open body {
     background: $green;
     color: white;
     font-weight: bold;
-    z-index: 100;
+    z-index: 10000;
 
     &.alert-error {
       background: $govuk-error-colour;


### PR DESCRIPTION
<img width="1532" alt="Screenshot 2020-12-01 at 11 44 20" src="https://user-images.githubusercontent.com/117398/100736389-9029c900-33ca-11eb-986e-0661ecd8518e.png">
