### PR TITLE
Don't add `diff` class to unchanged sections

### DIFF
--- a/client/components/diff-window.js
+++ b/client/components/diff-window.js
@@ -208,7 +208,7 @@ class DiffWindow extends React.Component {
             {
               parts.length
                 ? parts.map(({ value, added, removed }, i) => (
-                  <span key={i} className={classnames('diff', { added, removed })}>{ value }</span>
+                  <span key={i} className={classnames({ added, removed, diff: (added || removed) })}>{ value }</span>
                 ))
                 : <em>{DEFAULT_LABEL}</em>
             }
@@ -225,7 +225,7 @@ class DiffWindow extends React.Component {
               <ul>
                 {
                   parts.map(({ value, added, removed }, i) => {
-                    return value.map(v => <li key={i}><span className={classnames('diff', { added, removed })}>{ getLabel(v) }</span></li>)
+                    return value.map(v => <li key={i}><span className={classnames({ added, removed, diff: (added || removed) })}>{ getLabel(v) }</span></li>)
                   })
                 }
               </ul>


### PR DESCRIPTION
If a fragment of a list selection or plain text input is unchanged then don't add a `diff` class to it because that causes it to be highighted in green.

Only add the class if it is added or removed.