### PR TITLE
Remove wrapping `li` from permissible purpose diff

### DIFF
--- a/client/components/diff-window.js
+++ b/client/components/diff-window.js
@@ -179,13 +179,11 @@ const DiffWindow  = (props) => {
       return props.options
         .map(option => {
           if (option.value === 'translational-research') {
-            return <li>
-              <ul>
-                {
-                  option.reveal.options.map(o => <Option option={o} key={o.value} />)
-                }
-              </ul>
-            </li>;
+            return <ul>
+              {
+                option.reveal.options.map(o => <Option option={o} key={o.value} />)
+              }
+            </ul>;
           }
           return <Option option={option} key={option.value} />
         });


### PR DESCRIPTION
Having this results in an erroneous bullet marker, and it's not there in other places we display this value.