### PR TITLE
Add wrapping `p` tag to licence holder review

### DIFF
--- a/client/components/review-field.js
+++ b/client/components/review-field.js
@@ -92,7 +92,7 @@ class ReviewField extends React.Component {
 
     if (value && this.props.type === 'holder') {
       return (
-        <Link page="profile.read" profileId={value.licenceHolder.id} establishmentId={value.establishment.id} label={`${value.licenceHolder.firstName} ${value.licenceHolder.lastName}`} />
+        <p><Link page="profile.read" profileId={value.licenceHolder.id} establishmentId={value.establishment.id} label={`${value.licenceHolder.firstName} ${value.licenceHolder.lastName}`} /></p>
       );
     }
 


### PR DESCRIPTION
Otherwise weird spacing occurs

<img width="426" alt="Screenshot 2020-12-23 at 09 22 35" src="https://user-images.githubusercontent.com/117398/102981069-67e04680-4500-11eb-8cff-243f41c46745.png">