### PR TITLE
Only load diffs when the comparison window is open

### DIFF
--- a/client/components/diff-window.js
+++ b/client/components/diff-window.js
@@ -39,12 +39,12 @@ const DiffWindow  = (props) => {
   const before = useSelector(state => get(state.questionVersions, `${props.name}.${versions[active]}.value`));
 
   useEffect(() => {
-    if (!before) {
+    if (!before && modalOpen) {
       setLoading(true);
       dispatch(fetchQuestionVersions(props.name, { version: versions[active], type: props.type }))
         .then(() => setLoading(false));
     }
-  }, [props.name, versions[active]]);
+  }, [props.name, versions[active], modalOpen]);
 
   const toggleModal = e => {
     e.preventDefault();


### PR DESCRIPTION
This was sending requests for the first diff on load, where it needs to wait until the modal window is opened to avoid adding unnecessary load on the server.