### PR TITLE
Remove `title` from fields that flag a changed indicator on protocols

### DIFF
--- a/client/components/side-nav.js
+++ b/client/components/side-nav.js
@@ -26,6 +26,9 @@ function getFieldsForSection(section, project) {
   if (section.repeats) {
     fields.push(section.repeats);
   }
+  if (section.name === 'protocols') {
+    return fields.filter(f => f !== 'title');
+  }
   return fields;
 }
 


### PR DESCRIPTION
This was resulting in a changed marker showing against protocols in the side bar when the project title changed.

Do it here and not in the `getFields` helper because I am not confident in that not resultign in unintended side-effects if the same function is used elsewhere.