### PR TITLE
Handle field names with dots in them

### DIFF
--- a/client/components/diff-window.js
+++ b/client/components/diff-window.js
@@ -37,8 +37,8 @@ const DiffWindow  = (props) => {
 
   const dispatch = useDispatch();
 
-  const changes = useSelector(state => get(state.questionVersions, `${props.name}.${versions[active]}.diff`, { added: [], removed: [] }));
-  const before = useSelector(state => get(state.questionVersions, `${props.name}.${versions[active]}.value`));
+  const changes = useSelector(state => get(state.questionVersions, `['${props.name}'].${versions[active]}.diff`, { added: [], removed: [] }));
+  const before = useSelector(state => get(state.questionVersions, `['${props.name}'].${versions[active]}.value`));
 
   useEffect(() => {
     if (!before && modalOpen) {


### PR DESCRIPTION
Using `get` with simple string concatenation fails when the name of the field has dots in - i.e. when inside protocols. Use square bracket notation around the field name so that it handles names with dots in as well.