### PR TITLE
Swap condition to hide changes on first iteration

### DIFF
--- a/client/components/diff-window.js
+++ b/client/components/diff-window.js
@@ -26,10 +26,10 @@ const DiffWindow  = (props) => {
     const arr = [];
     if (props.changedFromGranted) {
       arr.push('granted');
-    } else if (props.changedFromFirst) {
+    } else if (props.changedFromFirst && !isFirstIteration) {
       arr.push('first');
     }
-    if (props.changedFromLatest && !isFirstIteration) {
+    if (props.changedFromLatest) {
       arr.push('latest');
     }
     return arr;


### PR DESCRIPTION
The server code returns `changedFromLatest` and not `changedFromFirst` when resubmitting an application for the first time, so make sure this logic is reflected here and `changedFromLatest` is preferred.

Otherwise the two conditions conflict and no version for comparison is found when reviewing the first iteration of an application.