### PR TITLE
Handle case where `application` is not defined

### DIFF
--- a/client/components/field.js
+++ b/client/components/field.js
@@ -299,7 +299,7 @@ const mapStateToProps = ({ project, settings, application }, { name, conditional
     showChanges: !!onFieldChange && application && !application.newApplication,
     value: !isUndefined(value) ? value : project && project[name],
     show: !conditional || every(Object.keys(conditional), key => conditional[key] === project[key]),
-    grantedVersion: application.grantedVersion
+    grantedVersion: application && application.grantedVersion
   };
 }
 


### PR DESCRIPTION
In some contexts - specifically changing a licence holder - the `application` property on the state is not defined, and so this throws an error.