### PR TITLE
Switch preference order of title loading

### DIFF
--- a/client/project-router.js
+++ b/client/project-router.js
@@ -95,7 +95,7 @@ const ProjectRouter = () => {
     ? 'application'
     : (isAmendment ? 'amendment' : 'application');
 
-  const projectTitle = project.title || version.title || 'Untitled project'
+  const projectTitle = version.title || project.title || 'Untitled project';
 
   return (
     <BrowserRouter basename={basename}>


### PR DESCRIPTION
I _think_ `project.title` was added to the options for RA to handle the case where there is no version, but it defaults to `Untitled project` and so when editing a draft the title always shows as `Untitled project` even if the draft has been given a title.

By preferring the title on the local version it stays updated when changing the title of the draft.