### PR TITLE
Bugfix - dont hide sections link

### DIFF
--- a/assets/scss/projects.scss
+++ b/assets/scss/projects.scss
@@ -398,8 +398,6 @@ html.modal-open, html.modal-open body {
     background-color: $black;
     color: $white;
     text-decoration: none;
-    position: relative;
-    top: -$govuk-gutter;
     margin-bottom: $govuk-gutter;
     display: inline-block;
     padding: 10px 16px;


### PR DESCRIPTION
* This css hides the back to sections link behind the header when the title is > 1 row