### PR TITLE
Fix images not displaying in docx downloads

### DIFF
--- a/client/components/download-link/renderers/docx-renderer.js
+++ b/client/components/download-link/renderers/docx-renderer.js
@@ -871,7 +871,7 @@ export default (application, sections, values, updateImageDimensions) => {
 
   const addImageDimensions = values => {
     return traverse(values, (value) => {
-      if (typeof value !== 'object' || typeof value !== 'string' || value === null) {
+      if ((typeof value !== 'object' && typeof value !== 'string') || value === null) {
         return Promise.resolve(value);
       }
 


### PR DESCRIPTION
The condition `not object OR not string` caused the function to always return early and skip the code below.