### PR TITLE
Add normalising function to remove invisible whitespace

### DIFF
--- a/client/components/diff-window.js
+++ b/client/components/diff-window.js
@@ -10,6 +10,8 @@ import Modal from './modal';
 import ReviewField from './review-field'
 import Tabs from './tabs';
 
+import normaliseWhitespace from '../../helpers/normalise-whitespace';
+
 const DEFAULT_LABEL = 'No answer provided';
 
 const DiffWindow  = (props) => {
@@ -78,7 +80,7 @@ const DiffWindow  = (props) => {
     const before = parseValue(a);
     const after = parseValue(b);
 
-    return before.document.text !== after.document.text;
+    return normaliseWhitespace(before.document.text) !== normaliseWhitespace(after.document.text);
   }
 
   const decorateNode = (parts) => {

--- a/client/components/editor/blocks/index.js
+++ b/client/components/editor/blocks/index.js
@@ -1,4 +1,6 @@
+import normaliseWhitespace from '../../helpers/normalise-whitespace';
 import renderBlock from './render-block';
+import { Text } from 'slate';
 
 const DEFAULT_BLOCK = 'paragraph';
 
@@ -55,6 +57,16 @@ const toggleBlock = (editor, type) => {
 
 export default function Blocks() {
   return {
+    // this needs to be american spelling and I don't like it either
+    normalizeNode: (node, editor, next) => {
+      if (node.object === 'text') {
+        const text = normaliseWhitespace(node.text);
+        if (node.text !== text) {
+          return () => editor.replaceNodeByKey(node.key, Text.create({ text }));
+        }
+      }
+      next();
+    },
     renderBlock,
     commands: {
       toggleBlock,

--- a/client/helpers/normalise-whitespace.js
+++ b/client/helpers/normalise-whitespace.js
@@ -1,0 +1,6 @@
+// eslint-disable-next-line no-control-regex
+const invisibleWhitespace = /[\u0000-\u0008\u000B-\u0019\u001b\u009b\u00ad\u200b\u2028\u2029\ufeff\ufe00-\ufe0f]/g;
+
+const normalise = str => str.replace(invisibleWhitespace, '');
+
+export default normalise;


### PR DESCRIPTION
This detects any invisible unicode characters that may appear from copying text from various sources and removes them.

Regex taken from https://github.com/xpl/printable-characters/blob/0b71bb1395659e929ca77ab200eb70691ee514dc/printable-characters.js#L4