### PR TITLE
Only show one comparison tab when previous and granted versions are the same

### DIFF
--- a/client/components/diff-window.js
+++ b/client/components/diff-window.js
@@ -36,7 +36,8 @@ const DiffWindow  = (props) => {
     } else if (props.changedFromFirst && !isFirstIteration) {
       arr.push('first');
     }
-    if (props.changedFromLatest) {
+    // if the latest version and the granted version are the same then don't add separate tabs
+    if (props.changedFromLatest && iterations[1].status !== 'granted') {
       arr.push('latest');
     }
     return arr;


### PR DESCRIPTION
In the case where an amendment is on it's first iteration we only want to show the granted lcience in the comparison window, and not add a second tab for "previous version" which shows the same version.

Check that the previous version is not granted and only show a second tab where there are enough versions to warrant the extra level of comparison.