### PR TITLE
Simplify change flags for nested repeaters

### DIFF
--- a/client/pages/sections/protocols/protocol-sections.js
+++ b/client/pages/sections/protocols/protocol-sections.js
@@ -13,7 +13,6 @@ import ChangedBadge from '../../../components/changed-badge';
 import NewProtocolBadge from '../../../components/new-protocol-badge';
 import ReorderedBadge from '../../../components/reordered-badge';
 import { filterSpeciesByActive } from './animals';
-import { flattenReveals } from '../../../helpers';
 
 import { keepAlive } from '../../../actions/session';
 
@@ -86,20 +85,6 @@ class ProtocolSections extends PureComponent {
 
     const noAnswer = <em>No answer provided</em>;
 
-    const fields = Object.values(sections)
-      .reduce((list, section) => {
-        const flattenedFields = flattenReveals(section.fields || [], values);
-
-        if (section.repeats && values[section.repeats]) {
-          values[section.repeats].filter(Boolean).forEach(repeater => {
-            list.push.apply(list, flattenedFields.map(f => `${section.repeats}.${repeater.id}.${f.name}`));
-          });
-          return list;
-        }
-        return list.concat(flattenedFields.map(field => field.name));
-      }, [])
-      .map(f => `protocols.${values.id}.${f}`);
-
     const title = values.title || 'Untitled protocol';
 
     return (
@@ -113,7 +98,7 @@ class ProtocolSections extends PureComponent {
             <Fragment>
               <NewProtocolBadge id={values.id} />
               <ReorderedBadge id={values.id} />
-              <ChangedBadge fields={fields} protocolId={values.id} />
+              <ChangedBadge fields={[`protocols.${values.id}`]} protocolId={values.id} />
             </Fragment>
           )
         }

--- a/client/pages/sections/protocols/sections.js
+++ b/client/pages/sections/protocols/sections.js
@@ -77,6 +77,9 @@ const getOpenSection = (protocolState, editable, sections) => {
 }
 
 const getFieldKeys = (section, values) => {
+  if (section.repeats) {
+    return [`protocols.${values.id}.${section.repeats}`];
+  }
   const flattenedFields = flattenReveals(section.fields || [], values);
   if (section.repeats) {
     return (values[section.repeats] || []).filter(Boolean).reduce((list, repeater) => {


### PR DESCRIPTION
Because the changes for repeaters are calculated to include paths at each level e.g. `protocols`, `protocols.<id>`, `protocols.<id>.steps` etc then there's no need to try to enumerate the fields inside these sections - which was being done incorrectly previously - and can simply pass the path to the section level into the changed indicator component.

This vastly reduces the complexity of calculation needed to be done to establish if a repeating section has changed.