### PR TITLE
Prevent error when only one visible version

### DIFF
--- a/client/components/diff-window.js
+++ b/client/components/diff-window.js
@@ -37,7 +37,7 @@ const DiffWindow  = (props) => {
       arr.push('first');
     }
     // if the latest version and the granted version are the same then don't add separate tabs
-    if (props.changedFromLatest && iterations[1].status !== 'granted') {
+    if (props.changedFromLatest && iterations[1] && iterations[1].status !== 'granted') {
       arr.push('latest');
     }
     return arr;


### PR DESCRIPTION
When an inspector looks at a PPL draft version there may only be one version, so the status check on `iterations[1]` throws. Check the iteration exists before reading the status.