### PR TITLE
Fix diff window display of animal quantities

### DIFF
--- a/client/helpers/index.js
+++ b/client/helpers/index.js
@@ -59,7 +59,17 @@ export function mapPermissiblePurpose(project) {
 }
 
 export function mapAnimalQuantities(project, name) {
-  const species = [].concat(project.species).concat(project['species-other']).filter(Boolean);
+  const species = []
+    .concat(project.species)
+    .reduce((arr, s) => {
+      if (s.match(/^other-/)) {
+        const others = castArray(project[`species-${s}`]);
+        return [ ...arr, ...others ];
+      }
+      return [ ...arr, s ];
+    }, [])
+    .filter(Boolean);
+
   return species
     .reduce((obj, key) => {
       return {

--- a/test/specs/helpers/map-animal-quanities.js
+++ b/test/specs/helpers/map-animal-quanities.js
@@ -1,0 +1,40 @@
+import assert from 'assert';
+import { mapAnimalQuantities } from '../../../client/helpers';
+
+describe('mapAnimalQuantities', () => {
+
+  it('returns a map of species to quantities', () => {
+    const project = {
+      species: ['mice', 'rats', 'guinea-pigs'],
+      'reduction-mice': '100',
+      'reduction-rats': '200',
+      'reduction-guinea-pigs': '300'
+    };
+    const output = mapAnimalQuantities(project, 'reduction');
+
+    assert.equal(output['reduction-mice'], '100');
+    assert.equal(output['reduction-rats'], '200');
+    assert.equal(output['reduction-guinea-pigs'], '300');
+    assert.deepEqual(output.species, ['mice', 'rats', 'guinea-pigs']);
+  });
+
+  it('includes "other" species types in map', () => {
+    const project = {
+      species: ['mice', 'other-rodents', 'other-fish'],
+      'species-other-rodents': ['capybara', 'chipmunk'],
+      'species-other-fish': 'carp',
+      'reduction-mice': '100',
+      'reduction-capybara': '200',
+      'reduction-chipmunk': '300',
+      'reduction-carp': '400'
+    };
+    const output = mapAnimalQuantities(project, 'reduction');
+
+    assert.equal(output['reduction-mice'], '100');
+    assert.equal(output['reduction-capybara'], '200');
+    assert.equal(output['reduction-chipmunk'], '300');
+    assert.equal(output['reduction-carp'], '400');
+    assert.deepEqual(output.species, ['mice', 'capybara', 'chipmunk', 'carp']);
+  });
+
+});


### PR DESCRIPTION
Where a project uses "other" types these are not being correctly rendered in the diff windows for the animal quantities section. Update `mapAnimalQuantities` function to include "other" types.