### PR TITLE
Allow conditions and authorisations textareas to expand

### DIFF
--- a/client/components/editable.js
+++ b/client/components/editable.js
@@ -51,6 +51,7 @@ class Editable extends Component {
         <TextArea
           value={content}
           onChange={this.onChange}
+          autoExpand={true}
         />
         <p className="control-panel">
           <Button disabled={updating} onClick={this.save} className="button-secondary">Save</Button>


### PR DESCRIPTION
All other instances of TextArea components in the app are expandable except the one for editing project conditions and authorisations, which is probably one of the most likely to contain a lot of text.