### PR TITLE
Back-off sync error retries and add retry limit

### DIFF
--- a/client/actions/messages.js
+++ b/client/actions/messages.js
@@ -21,9 +21,6 @@ export function showMessage(message) {
 export function throwError(message) {
   return (dispatch) => {
     clearTimeout(hideTimeout);
-    hideTimeout = setTimeout(() => {
-      dispatch(hideMessage());
-    }, 5000);
     return dispatch({ type: types.ERROR, error: { message } });
   };
 }

--- a/client/actions/projects.js
+++ b/client/actions/projects.js
@@ -242,11 +242,15 @@ const onSyncError = (func, err, dispatch, getState, ...args) => {
   console.error(err);
   dispatch(doneSyncing());
   dispatch(syncError());
-  dispatch(throwError(err.code === 'UPDATE_REQUIRED'
-    ? 'This software has been updated. You must refresh your browser to avoid losing work.'
-    : 'Failed to save, trying again'
-  ));
-  return setTimeout(() => func(dispatch, getState, ...args), 1000);
+  const errorCount = getState().application.errorCount;
+  if (err.code === 'UPDATE_REQUIRED') {
+    return dispatch(throwError('This software has been updated. You must refresh your browser to avoid losing work.'));
+  }
+  if (errorCount > 5) {
+    return dispatch(throwError('Failed to save your changes. Try refreshing your browser to continue. If the problem persists then please report to aspelqueries@homeoffice.gov.uk'));
+  }
+  dispatch(throwError(`Failed to save, trying again in ${Math.pow(2, errorCount)} seconds`));
+  return setTimeout(() => func(dispatch, getState, ...args), 1000 * Math.pow(2, errorCount));
 };
 
 function getProjectWithConditions(project) {

--- a/client/reducers/application.js
+++ b/client/reducers/application.js
@@ -6,6 +6,7 @@ const INITIAL_STATE = {
   establishment: null,
   isSyncing: false,
   syncError: false,
+  errorCount: 0,
   previousProtocols: {}
 };
 
@@ -33,12 +34,14 @@ export default function applicationReducer(state = INITIAL_STATE, action) {
     case types.SYNC_ERROR:
       return {
         ...state,
-        syncError: true
+        syncError: true,
+        errorCount: state.errorCount + 1
       }
     case types.SYNC_ERROR_RESOLVED:
       return {
         ...state,
-        syncError: false
+        syncError: false,
+        errorCount: 0
       }
     default:
       return state;


### PR DESCRIPTION
If an edit repeatedly fails to save then increase the timeout before retrying each time, and if it fails more than 5 times consecutively then display a different message and stop retrying.