### PR TITLE
Trim RTE nodes in read-only mode

### DIFF
--- a/client/components/editor/blocks/render-block.js
+++ b/client/components/editor/blocks/render-block.js
@@ -15,6 +15,10 @@ function Image(props) {
 const renderBlock = (props, editor, next) => {
   const { attributes, children, node, isFocused } = props;
 
+  if (props.readOnly && !node.text.trim().length) {
+    return null;
+  }
+
   function remove() {
     editor.removeNodeByKey(node.key);
   }


### PR DESCRIPTION
If a rich text element is in read only mode then don't render empty blocks. This prevent inconsistent whitespace between answers where the rich text content has trailing empty paragraphs.