### PR TITLE
Remove references to `uuid/v4`

### DIFF
--- a/client/components/conditions/add-conditions.js
+++ b/client/components/conditions/add-conditions.js
@@ -2,7 +2,7 @@ import React, { useState, useReducer, Fragment } from 'react';
 import { Button } from '@ukhomeoffice/react-components';
 import Condition from './condition';
 import Field from '../field';
-import uuid from 'uuid/v4';
+import { v4 as uuid } from 'uuid';
 import CONDITIONS from '../../constants/conditions';
 
 function CustomConditions({ conditions, onUpdate, onAdd, onRemove }) {

--- a/client/components/conditions/protocol-conditions.js
+++ b/client/components/conditions/protocol-conditions.js
@@ -1,6 +1,6 @@
 import React, { useState, Fragment } from 'react';
 import { connect } from 'react-redux';
-import uuid from 'uuid/v4';
+import { v4 as uuid } from 'uuid';
 import { Button } from '@ukhomeoffice/react-components';
 import { updateConditions } from '../../actions/projects';
 import Conditions from './conditions';

--- a/client/components/repeater.js
+++ b/client/components/repeater.js
@@ -2,7 +2,7 @@ import React, { Component, Fragment } from 'react';
 import classnames from 'classnames';
 import { connect } from 'react-redux';
 import { Button } from '@ukhomeoffice/react-components';
-import uuid from 'uuid/v4';
+import { v4 as uuid } from 'uuid';
 import cloneDeep from 'lodash/cloneDeep';
 import { throwError } from '../actions/messages';
 

--- a/client/pages/sections/protocols/animals.js
+++ b/client/pages/sections/protocols/animals.js
@@ -1,7 +1,7 @@
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
-import v4 from 'uuid/v4';
+import { v4 as uuid } from 'uuid';
 
 import some from 'lodash/some';
 import flatten from 'lodash/flatten';
@@ -121,7 +121,7 @@ class Animals extends Component {
       if (some(speciesDetails, sd => sd.name === item)) {
         return;
       }
-      speciesDetails.push({ name: item, id: v4(), value })
+      speciesDetails.push({ name: item, id: uuid(), value })
     });
 
     return filterSpeciesByActive({ speciesDetails, species }, project);

--- a/client/pages/sections/repeater/index.js
+++ b/client/pages/sections/repeater/index.js
@@ -1,5 +1,5 @@
 import React, { Fragment } from 'react';
-import uuid from 'uuid/v4';
+import { v4 as uuid } from 'uuid';
 import { Markdown } from '@asl/components';
 
 import Repeater from '../../../components/repeater-field';


### PR DESCRIPTION
This has been throwing deprecation warning for a while, but seems to now be failing in some contexts. Swap to the recommended approach for accessing the uuid v4 function.