### PR TITLE
Set add another label explicitly for additional establishments

### DIFF
--- a/client/schema/v1/index.js
+++ b/client/schema/v1/index.js
@@ -488,6 +488,7 @@ export default () => ({
             show: values => values['other-establishments'],
             repeats: 'establishments',
             singular: 'Additional establishment',
+            addAnotherLabel: 'Add another additional establishment',
             confirmRemove: confirmProtocolsAffected('remove', 'locations', 'establishment', 'establishment-name'),
             fields: [
               {


### PR DESCRIPTION
The default is `Add another ${props.singular}` which means the button has a random upper case A on `Additional`. Automatically lowercasing will break the repeater for `POLEs` so to get rid of the random A then it's easiest to explicitly define the button label.