### PR TITLE
Remove surplus "Other" from labels

### DIFF
--- a/client/components/species-selector.js
+++ b/client/components/species-selector.js
@@ -24,7 +24,7 @@ const getField = (options, name, fieldName) => ({
       return {
         ...option,
         reveal: {
-          label: `Specify other type of ${option.label.charAt(0).toLowerCase()}${option.label.substring(1)}`,
+          label: `Specify type of ${option.label.charAt(0).toLowerCase()}${option.label.substring(1)}`,
           name: `${fieldName}-${option.value}`,
           type: 'other-species-selector'
         }


### PR DESCRIPTION
Previously this would read `Specify other type of other rodents` etc. Remove the first "other".