### PR TITLE
Don't show empty establishment when user answers "no" to Additional Availability

### DIFF
--- a/client/pages/sections/establishments/review.js
+++ b/client/pages/sections/establishments/review.js
@@ -6,6 +6,7 @@ import ReviewFields from '../../../components/review-fields';
 
 export default function EstablishmentsReview({ steps, ...props }) {
   const { readonly } = useSelector(state => state.application);
+  const hasEstablishments = props.values['other-establishments'];
 
   return (
     <div className="establishments-review">
@@ -19,7 +20,7 @@ export default function EstablishmentsReview({ steps, ...props }) {
 
       <ReviewFields {...props} fields={steps[0].fields} />
 
-      <Establishments {...props} fields={steps[1].fields} editable={false} showTitle={false} />
+      { hasEstablishments && <Establishments {...props} fields={steps[1].fields} editable={false} showTitle={false} /> }
 
       <ReviewFields {...props} fields={steps[2].fields} showTitle={false} />
     </div>


### PR DESCRIPTION
The default state of the repeater review is an empty single item, which is incorrect in this context. Hide the establishment repeater completely unless the user has selected "yes" for additional establishments.