### PR TITLE
Fix comment counts for repeater sections

### DIFF
--- a/client/components/application-summary.js
+++ b/client/components/application-summary.js
@@ -109,25 +109,27 @@ class ApplicationSummary extends React.Component {
   }
 
   getCommentCount = (key, subsection) => {
+    let repeaterComments = 0;
 
     if (subsection.repeats) {
-      return flatten(Object.keys(this.props.newComments)
+      repeaterComments = flatten(Object.keys(this.props.newComments)
         .filter(key => key.match(new RegExp(`^${subsection.repeats}\\.`)))
         .map(key => this.props.newComments[key])).length;
-    } else {
-      return (this.props.fieldsBySection[key] || []).reduce((total, field) => {
-        if (field.includes('.*')) {
-          const prefix = field.split('.*')[0];
-          return total + Object.keys(this.props.newComments).reduce((sum, q) => {
-            if (q.split('.')[0] === prefix) {
-              return sum + this.props.newComments[q].length;
-            }
-            return sum;
-          }, 0);
-        }
-        return total + (this.props.newComments[field] || []).length
-      }, 0);
     }
+
+    return (this.props.fieldsBySection[key] || []).reduce((total, field) => {
+      if (field.includes('.*')) {
+        const prefix = field.split('.*')[0];
+        return total + Object.keys(this.props.newComments).reduce((sum, q) => {
+          if (q.split('.')[0] === prefix) {
+            return sum + this.props.newComments[q].length;
+          }
+          return sum;
+        }, 0);
+      }
+      return total + (this.props.newComments[field] || []).length
+    }, repeaterComments);
+
   }
 
   getComments = (key, subsection) => {


### PR DESCRIPTION
Some sections have a repeating and a non-repeating element. The previous implementation of the comment count was only including comments within the repeating element of the section and not the non-repeating elements.

Where a section has a repeating element use that as the starting value for the "normal" comment counting `reduce` so that all comments are included.