### PR TITLE
Fix comment counts for repeating fields

### DIFF
--- a/client/helpers/index.js
+++ b/client/helpers/index.js
@@ -142,6 +142,12 @@ export const flattenReveals = (fields, values) => {
 };
 
 export function getFields(section) {
+  if (section.name === 'protocols') {
+    return flatten(Object.values(section.sections).concat(section.fields).map(getFields))
+      .map(field => {
+        return { ...field, name: `protocols.*.${field.name}` };
+      });
+  }
   if (section.fields && section.fields.length) {
     return section.fields.map(field => {
       if (field.repeats) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3327,9 +3327,9 @@
       "integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ=="
     },
     "balanced-match": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "base64-js": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "jsondiffpatch": "^0.4.1",
     "lodash": "^4.17.21",
     "mdn-polyfills": "^5.15.0",
+    "minimatch": "^3.0.4",
     "r2": "^2.0.1",
     "react": "^16.9.0",
     "react-addons-css-transition-group": "^15.6.2",


### PR DESCRIPTION
Different sections have different ways of handling repeating field definition and enumeration. Ensure that these are all represented consistently in the comment counting by ensuring that all sections return a complete list of fields with repeating components wildcarded. Previously the protocols section was disregarded, for unknown reasons.

Then filter the comments based on a wildcard match against the field list.