### PR TITLE
Use minimatch to compare changed fields

### DIFF
--- a/client/components/changed-badge.js
+++ b/client/components/changed-badge.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useSelector, shallowEqual } from 'react-redux';
+import minimatch from 'minimatch';
 
 const selector = ({
   changes: {
@@ -24,10 +25,9 @@ export default function ChangedBadge({ fields = [], changedFromGranted, changedF
   }
   const changedFrom = source => {
     return source.length && fields.some(field => {
-      if (field.includes('*')) {
-        field = field.split('.*')[0];
-      }
-      return source.some(change => change === field)
+      return source.some(change => {
+        return minimatch(change, field);
+      })
     });
   }
 


### PR DESCRIPTION
The previous code expected the changes to contain `protocols` when something inside protocols had changed, which is not the case. The protocol changes are all listed as `protocols.<id>.title` etc, so use minimatch to compare these with `protocols.*.title` as is in the fields array.