### PR TITLE
Fix protocols section name in legacy schema

### DIFF
--- a/client/schema/v0/index.js
+++ b/client/schema/v0/index.js
@@ -346,7 +346,7 @@ export default () => ({
     subsections: {
       protocols: {
         title: 'Protocols',
-        name: 'protocol',
+        name: 'protocols',
         component: Protocols,
         review: ProtocolsReview,
         granted: {


### PR DESCRIPTION
This was causing the custom mapping of fields to break because it was expecting the protocols section to be called `protocols`.