### PR TITLE
Restrict trigger for transfer of animals condition

### DIFF
--- a/client/constants/conditions.js
+++ b/client/constants/conditions.js
@@ -210,7 +210,7 @@ Genetically altered animals may not be re-homed.`
       ]
     },
     transferAndMovement: {
-      include: project => project.transfer,
+      include: project => project.transfer && project['other-establishments'],
       type: 'authorisation',
       versions: [
         {


### PR DESCRIPTION
The transfer of animals question only appears if other establishments are selected, but there have been cases where additional establishments have been added, the transfer question answered as "Yes" and then the additional establishments removed.

In this case the condition should also be removed.