### PR TITLE
Bugfix: Make sure empty table cells get rendered for readonly view

### DIFF
--- a/client/components/editor/blocks/render-block.js
+++ b/client/components/editor/blocks/render-block.js
@@ -15,7 +15,7 @@ function Image(props) {
 const renderBlock = (props, editor, next) => {
   const { attributes, children, node, isFocused } = props;
 
-  if (node.type !== 'image' && props.readOnly && !node.text.trim().length) {
+  if (!['image', 'table-cell'].includes(node.type) && props.readOnly && !node.text.trim().length) {
     return null;
   }
 


### PR DESCRIPTION
Empty table cells that were present in the edit view:
![edit](https://user-images.githubusercontent.com/1880478/152973783-2ce3f853-cabe-43f1-a713-951971818e0c.png)

were being stripped from the readonly view:
![readonly](https://user-images.githubusercontent.com/1880478/152973843-00f69989-85d4-454a-b45e-65b6f399da8c.png)

Fix: make sure empty cells get rendered in tables in readonly view.
![fix](https://user-images.githubusercontent.com/1880478/152974190-86a942c9-4dde-45e2-802f-385fe26c4729.png)

