### PR TITLE
Make horizontal table scroll more obvious for readonly tables

### DIFF
--- a/assets/scss/projects.scss
+++ b/assets/scss/projects.scss
@@ -1153,6 +1153,7 @@ html.modal-open, html.modal-open body {
 
       table {
         color: $govuk-text-colour;
+        margin-bottom: 0;
       }
 
       .grey {

--- a/client/components/editor/table/renderers.js
+++ b/client/components/editor/table/renderers.js
@@ -1,9 +1,21 @@
 import React from 'react';
+import { OverflowWrapper } from '@asl/components';
 
 const renderBlock = (props, editor, next) => {
-  const { attributes, children, node } = props;
+  const { attributes, children, node, readOnly } = props;
   switch (node.type) {
     case 'table':
+      if (readOnly) {
+        return (
+          <div className="force-show-scrollbars">
+            <OverflowWrapper>
+              <table {...attributes}>
+                <tbody>{children}</tbody>
+              </table>
+            </OverflowWrapper>
+          </div>
+        );
+      }
       return (
         <table {...attributes}>
           <tbody>{children}</tbody>

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,13 +5,13 @@
   "requires": true,
   "dependencies": {
     "@asl/components": {
-      "version": "10.8.2",
-      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/components/-/@asl/components-10.8.2.tgz",
-      "integrity": "sha1-Lsgfcy5ia1HrzzfKAWFTJkNOGNw=",
+      "version": "10.12.1",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/components/-/@asl/components-10.12.1.tgz",
+      "integrity": "sha1-r8qtS5gsoNNEdPVuHHWohpDIc94=",
       "requires": {
         "@asl/constants": "^1.0.0",
         "@asl/dictionary": "^1.1.5",
-        "@ukhomeoffice/react-components": "^0.9.4",
+        "@ukhomeoffice/react-components": "^0.10.1",
         "accessible-autocomplete": "^2.0.3",
         "babel-plugin-transform-class-properties": "^6.24.1",
         "classnames": "^2.2.6",
@@ -26,6 +26,17 @@
         "redux": "^4.0.1",
         "url": "^0.11.0",
         "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "@ukhomeoffice/react-components": {
+          "version": "0.10.3",
+          "resolved": "https://registry.npmjs.org/@ukhomeoffice/react-components/-/react-components-0.10.3.tgz",
+          "integrity": "sha512-xuyDo6OQyuzgoBunzZEx9+qPfd6hOvD3ZgrR3qr4o26bRIBcvI94TxqJQ/d43iCIl7grLgfCucuPcd5ebpE/zg==",
+          "requires": {
+            "classnames": "^2.2.6",
+            "react-markdown": "^6.0.2"
+          }
+        }
       }
     },
     "@asl/constants": {
@@ -2872,9 +2883,9 @@
       }
     },
     "accessible-autocomplete": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/accessible-autocomplete/-/accessible-autocomplete-2.0.3.tgz",
-      "integrity": "sha512-bUswBs/mDH17dUFRAJMTtcGafJ++w1YLPPFjdfJj3lnuBsLpByAw2gmr8qxXX8oc7tzoKS3Ay5FKOPM+WMBxIw==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/accessible-autocomplete/-/accessible-autocomplete-2.0.4.tgz",
+      "integrity": "sha512-2p0txrSpvs5wXFUeQJHMheDPTZVSEmiUHWlEPb7vJnv2Dd1xPfoLnBQQMfNbTSit2pL/9sSQYESuD2Yyohd4Yw==",
       "requires": {
         "preact": "^8.3.1"
       }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "registry": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/"
   },
   "dependencies": {
-    "@asl/components": "^10.8.2",
+    "@asl/components": "^10.12.1",
     "@asl/constants": "^1.0.0",
     "@asl/service": "^8.8.4",
     "@babel/core": "^7.2.2",


### PR DESCRIPTION
It was not obvious that some tables were wider than the space available and therefore needed scrolling.

This adds an always-on horizontal scrollbar if the table overflows it's container.

Supported: Edge, Chrome, Safari
Not supported: Firefox

Needs:
 - https://github.com/UKHomeOffice/asl-components/pull/246