### PR TITLE
Compatibility fixes for dart sass

### DIFF
--- a/assets/scss/projects.scss
+++ b/assets/scss/projects.scss
@@ -255,7 +255,7 @@ html.modal-open, html.modal-open body {
       }
 
       h3:visited {
-        @extend a:visited;
+        @extend a, :visited;
       }
 
       span {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,13 +5,13 @@
   "requires": true,
   "dependencies": {
     "@asl/components": {
-      "version": "10.12.1",
-      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/components/-/@asl/components-10.12.1.tgz",
-      "integrity": "sha1-r8qtS5gsoNNEdPVuHHWohpDIc94=",
+      "version": "10.12.2",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/components/-/@asl/components-10.12.2.tgz",
+      "integrity": "sha1-Vlkl7GjNIZJ4yltI9fAGBLiDk8I=",
       "requires": {
         "@asl/constants": "^1.0.0",
         "@asl/dictionary": "^1.1.5",
-        "@ukhomeoffice/react-components": "^0.10.1",
+        "@ukhomeoffice/react-components": "^0.10.5",
         "accessible-autocomplete": "^2.0.3",
         "babel-plugin-transform-class-properties": "^6.24.1",
         "classnames": "^2.2.6",
@@ -26,17 +26,6 @@
         "redux": "^4.0.1",
         "url": "^0.11.0",
         "uuid": "^8.3.2"
-      },
-      "dependencies": {
-        "@ukhomeoffice/react-components": {
-          "version": "0.10.3",
-          "resolved": "https://registry.npmjs.org/@ukhomeoffice/react-components/-/react-components-0.10.3.tgz",
-          "integrity": "sha512-xuyDo6OQyuzgoBunzZEx9+qPfd6hOvD3ZgrR3qr4o26bRIBcvI94TxqJQ/d43iCIl7grLgfCucuPcd5ebpE/zg==",
-          "requires": {
-            "classnames": "^2.2.6",
-            "react-markdown": "^6.0.2"
-          }
-        }
       }
     },
     "@asl/constants": {
@@ -2854,9 +2843,9 @@
       }
     },
     "@ukhomeoffice/react-components": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/@ukhomeoffice/react-components/-/react-components-0.9.4.tgz",
-      "integrity": "sha512-thRHKKRenPTO74MmrCiFQLlcC5OfQ2xbGLtG6ey0FYMNkx4fz48d3kA1wc8rIR5CSuWlv1Dk9p0JbzJetmjvPQ==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@ukhomeoffice/react-components/-/react-components-0.10.5.tgz",
+      "integrity": "sha512-f0v1rEVdys/kdEpZK7BMYJ7kRHHvh4BlFKqlduF1lV6xkQZjaS1gqRQbcrBpT5svBDKUrbCRhcoSYGEx2aKGVQ==",
       "requires": {
         "classnames": "^2.2.6",
         "react-markdown": "^6.0.2"

--- a/package.json
+++ b/package.json
@@ -24,14 +24,14 @@
     "registry": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/"
   },
   "dependencies": {
-    "@asl/components": "^10.12.1",
+    "@asl/components": "^10.12.2",
     "@asl/constants": "^1.0.0",
     "@asl/service": "^8.8.4",
     "@babel/core": "^7.2.2",
     "@joefitter/slate-edit-list": "0.0.3",
     "@joefitter/slate-edit-table": "0.0.3",
     "@ukhomeoffice/frontend-toolkit": "^2.8.1",
-    "@ukhomeoffice/react-components": "^0.9.4",
+    "@ukhomeoffice/react-components": "^0.10.5",
     "classnames": "^2.2.6",
     "date-fns": "^1.30.1",
     "details-element-polyfill": "^2.3.0",


### PR DESCRIPTION
Dart Sass does not support extending compound selectors like `a:visited` (which libsass did).

https://sass-lang.com/documentation/breaking-changes/extend-compound