### PR TITLE
Prevent multiple comments if double-clicking

### DIFF
--- a/client/components/comments/add-comment.js
+++ b/client/components/comments/add-comment.js
@@ -9,7 +9,8 @@ class AddComment extends Component {
 
   state = {
     comment: '',
-    adding: false
+    adding: false,
+    saving: false
   };
 
   onChange = e => {
@@ -20,13 +21,17 @@ class AddComment extends Component {
   }
 
   onSubmit = () => {
+    if (!this.state.comment) {
+      return;
+    }
+    this.setState({ saving: true });
     this.props.addComment({
       field: this.props.field,
       comment: this.state.comment
     })
       .then(() => {
         if (this._isMounted) {
-          this.setState({ comment: '', adding: false });
+          this.setState({ comment: '', adding: false, saving: false });
         }
       });
   }
@@ -49,7 +54,7 @@ class AddComment extends Component {
   }
 
   render() {
-    const { comment, adding } = this.state;
+    const { comment, adding, saving } = this.state;
     return adding
       ? (
         <Fragment>
@@ -62,7 +67,7 @@ class AddComment extends Component {
             autoFocus
           />
           <p className="control-panel">
-            <Button onClick={this.onSubmit}>Save</Button>
+            <Button onClick={this.onSubmit} disabled={saving}>Save</Button>
             <Button className="link" onClick={this.clear}>Discard</Button>
           </p>
         </Fragment>


### PR DESCRIPTION
Disable the Save button in the add comment component when clicked so that if a user inadvertently double-clicks then the comment is still only saved once.

Also add a check for completely empty comments.