### PR TITLE
Improve messaging when adding additional establishments in PPL application

### DIFF
--- a/client/pages/sections/establishments/establishments.js
+++ b/client/pages/sections/establishments/establishments.js
@@ -5,6 +5,7 @@ import classnames from 'classnames';
 import Repeater from '../../../components/repeater';
 import Fieldset from '../../../components/fieldset';
 import ReviewFields from '../../../components/review-fields';
+import { Warning } from '@ukhomeoffice/react-components';
 
 const getItems = (values, editable, previousAA) => {
   let items = values['establishments'];
@@ -42,6 +43,7 @@ function Establishment(props) {
           editable && <a href="#" className={classnames('inline-block float-right', { restore: values.deleted })} onClick={values.deleted ? restoreItem : removeItem}>{values.deleted ? 'Restore' : 'Remove'}</a>
         }
         <h2>{`Additional establishment ${number + 1}`}</h2>
+        { editable && <Warning className="larger">This establishment will also need to conduct an AWERB review of this application before it can be submitted.</Warning> }
         {
           (values.deleted || !editable)
             ? <ReviewFields

--- a/client/pages/sections/establishments/index.js
+++ b/client/pages/sections/establishments/index.js
@@ -25,13 +25,14 @@ export default function Index({ advance, exit, ...props }) {
           <legend className="govuk-fieldset__legend">
             <h2 className="govuk-fieldset__heading govuk-heading-l larger">Primary establishment</h2>
           </legend>
-          {
-            transferToEstablishmentName ? <p className="larger">{transferToEstablishmentName}</p> : <p className="larger">{establishment.name}</p>
-          }
-          {
-            isActive ? <p className="larger"><Link to="/" label="Change"/></p>
-              : <p className="larger"><Link page="project.transferDraft" label="Change" establishmentId={establishment.id} projectId={project.id} /></p>
-          }
+          <p className="larger">{transferToEstablishmentName || establishment.name}</p>
+          <p className="larger">
+            {
+              isActive
+                ? <Link to="/" label="Change"/>
+                : <Link page="project.transferDraft" label="Change" establishmentId={establishment.id} projectId={project.id} />
+            }
+          </p>
         </fieldset>
       </div>
       <Establishments {...props} editable={true} />

--- a/client/pages/sections/establishments/index.js
+++ b/client/pages/sections/establishments/index.js
@@ -1,11 +1,39 @@
 import React from 'react';
 import Establishments from './establishments';
 import Controls from '../../../components/controls';
+import {shallowEqual, useSelector} from "react-redux";
+import {Link} from "@asl/components";
 
 export default function Index({ advance, exit, ...props }) {
+  const {
+    establishment,
+    project: {
+      ...project
+    }
+  } = useSelector(state => state.application, shallowEqual);
+
+  const transferToEstablishmentName = useSelector(state => state.project.transferToEstablishmentName, shallowEqual);
+
+  const isActive = project.status === 'active';
+
   return (
     <div className="establishments-section">
       <h1>Establishments</h1>
+      <p className="larger">Add any additional establishments where work on this project will be carried out beyond just the primary establishment.</p>
+      <div className="govuk-form-group">
+        <fieldset className="govuk-fieldset inline smaller">
+          <legend className="govuk-fieldset__legend">
+            <h2 className="govuk-fieldset__heading govuk-heading-l larger">Primary establishment</h2>
+          </legend>
+          {
+            transferToEstablishmentName ? <p className="larger">{transferToEstablishmentName}</p> : <p className="larger">{establishment.name}</p>
+          }
+          {
+            isActive ? <p className="larger"><Link to="/" label="Change"/></p>
+              : <p className="larger"><Link page="project.transferDraft" label="Change" establishmentId={establishment.id} projectId={project.id} /></p>
+          }
+        </fieldset>
+      </div>
       <Establishments {...props} editable={true} />
       <Controls onContinue={advance} onExit={exit} />
     </div>


### PR DESCRIPTION
- Add new content based on designs below
- Added dynamically updating establishment name if the primary establishment is updated on the previous page
- If it is a draft application it uses the existing transferDraft behaviour when changing the primary establishment, if it is an amendment it goes to the previous page where it allows the user to change the primary establishment

Remade PR from https://github.com/UKHomeOffice/asl-projects/pull/801 as this one was missing content

Screenshot of added content, designs found here: https://w3iqpx.axshare.com/#id=36lndd&p=page_1

<img width="630" alt="Screenshot 2022-07-06 at 17 33 40" src="https://user-images.githubusercontent.com/61828376/177599763-ef7a25c9-5ef1-48d3-a693-5f24b32effe2.png">


When the user chooses to update the primary establishment this is shown on the next page

<img width="642" alt="Screenshot 2022-07-06 at 17 34 15" src="https://user-images.githubusercontent.com/61828376/177599849-ca3d8654-cb80-4941-9ecb-c61d909d472f.png">
<img width="615" alt="Screenshot 2022-07-06 at 17 34 44" src="https://user-images.githubusercontent.com/61828376/177599934-3dee5614-94ec-403b-a740-3cebfbd51a55.png">

When they click 'Change' from this page they are returned to the previous screen as it is an amendment


