### PR TITLE
Build image sources dynamically with configured root URL

### DIFF
--- a/client/components/editor/blocks/render-block.js
+++ b/client/components/editor/blocks/render-block.js
@@ -1,13 +1,18 @@
 import React from 'react';
+import { useSelector } from 'react-redux';
 import { Button } from '@ukhomeoffice/react-components';
 
-function Image(props) {
+function Image({ src, token, remove, loading }) {
+  const imageRoot = useSelector(state => state.static.imageRoot || '/attachment', []);
+  if (!src && token) {
+    src = `${imageRoot}/${token}`;
+  }
   return (
     <div className="image-wrapper">
       <div className="image-overlay">
-        <Button onClick={props.remove} className="button-warning">Remove image</Button>
+        <Button onClick={remove} className="button-warning">Remove image</Button>
       </div>
-      <p>{ props.loading ? 'Saving image...' : <img {...props} /> }</p>
+      <p>{ loading ? 'Saving image...' : <img src={src} /> }</p>
     </div>
   )
 }
@@ -35,7 +40,8 @@ const renderBlock = (props, editor, next) => {
     case 'image': {
       const src = node.data.get('src');
       const loading = node.data.get('loading');
-      return <Image src={src} loading={loading} {...attributes} selected={isFocused} remove={remove} />
+      const token = node.data.get('token');
+      return <Image src={src} token={token} loading={loading} {...attributes} selected={isFocused} remove={remove} />
     }
     case 'block': {
       return <span {...attributes}>{children}</span>

--- a/client/components/editor/image/index.js
+++ b/client/components/editor/image/index.js
@@ -67,7 +67,7 @@ const onClickImage = (editor, event) => {
         if (!token) {
           throw new Error('Failed to save image');
         }
-        editor.setNodeByKey(key, { data: { loading: false, src: `/attachment/${token}` } });
+        editor.setNodeByKey(key, { data: { loading: false, token } });
       })
       .catch(e => {
         editor.removeNodeByKey(key);


### PR DESCRIPTION
Images in PDFs loaded from S3 need to have the full domain defined, so the source needs to be dynamic depending on the defined root URL.

If a `src` attribute is defined then it's almost certainly an old `data:` url, and so should be left intact.