### PR TITLE
Fix custom conditions

### DIFF
--- a/client/components/conditions/add-conditions.js
+++ b/client/components/conditions/add-conditions.js
@@ -6,7 +6,7 @@ import { v4 as uuid } from 'uuid';
 import CONDITIONS from '../../constants/conditions';
 
 function CustomConditions({ conditions, onUpdate, onAdd, onRemove }) {
-  const handleOnUpdate = index => val => onUpdate(index, val);
+  const handleOnUpdate = index => val => onUpdate(index, val.content);
 
   return (
     <Fragment>


### PR DESCRIPTION
Since the addition of reminders, the structure of the emitted value of a `Condition` component is `{ content, reminders }` but the `CustomCondition` component is expected to emit a string.

This resulted in the custom conditions being saved as `[object Object]` rather than the correct value.