### PR TITLE
Fix saving legacy conditions

### DIFF
--- a/client/pages/sections/legacy-conditions.js
+++ b/client/pages/sections/legacy-conditions.js
@@ -47,7 +47,7 @@ function LegacyConditions({
   function updateCustom(content) {
     props.saveConditions([
       ...(values.conditions || []).filter(c => c.key !== 'custom'),
-      { key: 'custom', content }
+      { key: 'custom', content: content.content }
     ]);
   }
 

--- a/client/pages/sections/legacy-introduction-review.js
+++ b/client/pages/sections/legacy-introduction-review.js
@@ -16,13 +16,13 @@ const LegacyIntroduction = ({ fields, project, values, pdf, readonly, title, lic
       name: 'holder',
       type: 'holder'
     };
-    const value = {
+    const holder = {
       licenceHolder,
       establishment
     };
 
     fields.splice(1, 0, field);
-    values.holder = value;
+    values = { ...values, holder };
   }
 
   const continuationField = fields.find(f => f.name === 'continuation');


### PR DESCRIPTION
Since the addition of reminders the edit condition component now emits an object as a value rather than a string so need to save the `content` property of the emitted value otherwise the condition is rendered as `[object Object]`.

Also fix a weird bug where if an inspector visits the introductory details page before editing conditions then the syncing indicator never completes because it thinks there's an unsynced change to the `holder` property on the local values.