### PR TITLE
Add loading screen when submitting a PPL that is still syncing

### DIFF
--- a/assets/scss/projects.scss
+++ b/assets/scss/projects.scss
@@ -1597,3 +1597,26 @@ html.modal-open, html.modal-open body {
     align-items: stretch;
   }
 }
+
+.holding-page {
+  text-align: center;
+  margin-bottom: 2em;
+}
+.spinner {
+  border: 12px solid #DEE0E2;
+  border-radius: 50%;
+  border-top-color: #808080;
+  width: 40px;
+  height: 40px;
+  -webkit-animation: spin 1.5s linear infinite;
+  animation: spin 1.5s linear infinite;
+  margin: 0 auto;
+}
+@-webkit-keyframes spin {
+  0% { -webkit-transform: rotate(0deg); }
+  100% { -webkit-transform: rotate(360deg); }
+}
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}

--- a/client/components/holding-page.js
+++ b/client/components/holding-page.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import Spinner from './spinner';
+
+export default function HoldingPage() {
+  return (
+    <div className="holding-page">
+      <h1>Your request is being processed</h1>
+      <h2>This should only take a few seconds</h2>
+      <Spinner />
+    </div>
+  )
+}

--- a/client/components/spinner.js
+++ b/client/components/spinner.js
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export default function Spinner() {
+  return (
+    <div className="spinner" />
+  )
+}

--- a/client/components/sync-handler.js
+++ b/client/components/sync-handler.js
@@ -3,7 +3,7 @@ import { useSelector, shallowEqual } from 'react-redux'
 import isEqual from 'lodash/isEqual';
 import classnames from 'classnames';
 
-const selector = ({
+export const selector = ({
   project: version,
   savedProject,
   application: {
@@ -53,7 +53,7 @@ const SyncHandler = () => {
       }
       statusMessage && (statusMessage.innerText = '');
     }
-  })
+  }, [isSyncing]);
 
   return <div className={classnames('sync-indicator', { syncing: isSyncing })}></div>;
 };


### PR DESCRIPTION
Instead of displaying an `onbeforeunload` popup, if someone tries to submit a PPL while the data is still syncing then add an intermediate loading screen that shows a message to wait for a few seconds while the sync completes before moving on to the submission screen once the data is saved.