### PR TITLE
Don't show saved indicator in readonly state

### DIFF
--- a/client/components/sync-handler.js
+++ b/client/components/sync-handler.js
@@ -14,12 +14,16 @@ export const selector = ({
   // only compare version data if version is in an editable state
   const editable = !readonly || editConditions;
   const isSyncing = editable && !isEqual(version, savedProject);
-  return { isSyncing };
+  return { isSyncing, editable };
 };
 
 const SyncHandler = () => {
 
-  const { isSyncing } = useSelector(selector, shallowEqual);
+  const { isSyncing, editable } = useSelector(selector, shallowEqual);
+
+  if (!editable) {
+    return null;
+  }
 
   useEffect(() => {
     window.onbeforeunload = () => {


### PR DESCRIPTION
If the application is in a readonly view then don't put a `Saved` message in the header.