### PR TITLE
Fix error handler POST

### DIFF
--- a/client/actions/messaging.js
+++ b/client/actions/messaging.js
@@ -4,15 +4,18 @@ export function postError({ error, info }) {
   const params = {
     method: 'POST',
     credentials: 'include',
-    json: {
+    body: JSON.stringify({
       message: error.message,
       stack: error.stack,
       url: document.URL,
       ...info
+    }),
+    headers: {
+      'content-type': 'application/json'
     }
   };
 
-  return fetch('/error', params).response.catch(() => {});
+  return fetch('/error', params).catch(() => {});
 }
 
 export default function sendMessage({ method, data, url }) {


### PR DESCRIPTION
This was using `r2` but `r2` has been removed in favour of native `fetch` which uses a slightly different API. Convert the POST of error details to the server to use native `fetch` API and so prevent the error handler from throwing an error.