### PR TITLE
Fix: trigger 13d condition on domestic fowl

### DIFF
--- a/client/components/conditions/add-conditions.js
+++ b/client/components/conditions/add-conditions.js
@@ -38,15 +38,17 @@ function CustomConditions({ conditions, onUpdate, onAdd, onRemove, conditionKey 
 }
 
 const getConditions = (type, omit = []) => {
-  return Object.keys(CONDITIONS.inspector)
-    .filter(key => CONDITIONS.inspector[key].type === type)
+  const conditions = { ...CONDITIONS.inspector, ...CONDITIONS.project };
+
+  return Object.keys(conditions)
+    .filter(key => conditions[key].type === type)
     .filter(key => !omit.includes(key))
     .map(key => ({
       key,
       type,
       checked: false,
       inspectorAdded: true,
-      ...CONDITIONS.inspector[key].versions[CONDITIONS.inspector[key].versions.length - 1]
+      ...conditions[key].versions[conditions[key].versions.length - 1]
     }));
 };
 

--- a/client/constants/conditions.js
+++ b/client/constants/conditions.js
@@ -274,7 +274,7 @@ Genetically altered animals may not be re-homed.`
     },
     'non-purpose-bred-sched-2': {
       include: project => {
-        const nopes = [
+        const triggers = [
           'mice',
           'rats',
           'guinea-pigs',
@@ -284,6 +284,7 @@ Genetically altered animals may not be re-homed.`
           'cats',
           'dogs',
           'ferrets',
+          'fowl',
           'other-domestic-fowl',
           'other-birds',
           'common-frogs',
@@ -293,7 +294,7 @@ Genetically altered animals may not be re-homed.`
           'pigs',
           'sheep'
         ];
-        return nopes.some(species => (project.species || []).includes(species)) && project['purpose-bred'] === false;
+        return triggers.some(species => (project.species || []).includes(species)) && project['purpose-bred'] === false;
       },
       type: 'condition',
       versions: [


### PR DESCRIPTION
Also allow inspectors to add any project condition to a licence if it's not triggered automatically.