### PR TITLE
Fix jumping cursor bug in Chrome 105

### DIFF
--- a/assets/scss/_editor.scss
+++ b/assets/scss/_editor.scss
@@ -28,6 +28,9 @@
   }
 
   &:not(.readonly) {
+    [data-slate-editor="true"] {
+      -webkit-user-modify: read-write!important;
+    }
     .image-wrapper:hover .image-overlay {
       display: block;
     }


### PR DESCRIPTION
Override the `-webkit-user-modify: read-write-plaintext-only` style that is added by slate to the editor element that causes a cursor jumping bug in Chrome 105.

Details at https://github.com/ianstormtaylor/slate/issues/5110