### PR TITLE
Removing species from project level should flag protocol as changed

### DIFF
--- a/client/pages/sections/protocols/animals.js
+++ b/client/pages/sections/protocols/animals.js
@@ -18,18 +18,6 @@ import Repeater from '../../../components/repeater';
 
 const allSpecies = flatten(Object.values(SPECIES));
 
-function getProjectSpecies(project) {
-  return flatten([
-    ...(project.species || []).map(s => {
-      if (s.indexOf('other') > -1) {
-        return project[`species-${s}`];
-      }
-      return s;
-    }),
-    ...(project['species-other'] || [])
-  ]);
-}
-
 function normaliseValues(speciesDetails) {
   return speciesDetails.map(details => {
     if (details.value) {
@@ -46,10 +34,9 @@ function normaliseValues(speciesDetails) {
 
 export function filterSpeciesByActive(protocol, project) {
   const { species = [], speciesDetails = [] } = protocol;
-  const projectSpecies = getProjectSpecies(project);
 
   return normaliseValues(speciesDetails).filter(s => {
-    return (species.includes(s.value) || species.includes(s.name)) && (projectSpecies.includes(s.value) || projectSpecies.includes(s.name));
+    return species.includes(s.value) || species.includes(s.name);
   });
 }
 

--- a/client/pages/sections/protocols/animals.js
+++ b/client/pages/sections/protocols/animals.js
@@ -18,6 +18,18 @@ import Repeater from '../../../components/repeater';
 
 const allSpecies = flatten(Object.values(SPECIES));
 
+function getProjectSpecies(project) {
+  return flatten([
+    ...(project.species || []).map(s => {
+      if (s.indexOf('other') > -1) {
+        return project[`species-${s}`];
+      }
+      return s;
+    }),
+    ...(project['species-other'] || [])
+  ]);
+}
+
 function normaliseValues(speciesDetails) {
   return speciesDetails.map(details => {
     if (details.value) {
@@ -34,9 +46,10 @@ function normaliseValues(speciesDetails) {
 
 export function filterSpeciesByActive(protocol, project) {
   const { species = [], speciesDetails = [] } = protocol;
+  const projectSpecies = getProjectSpecies(project);
 
   return normaliseValues(speciesDetails).filter(s => {
-    return species.includes(s.value) || species.includes(s.name);
+    return (species.includes(s.value) || species.includes(s.name)) && (projectSpecies.includes(s.value) || projectSpecies.includes(s.name));
   });
 }
 

--- a/test/specs/helpers/clean-protocols.js
+++ b/test/specs/helpers/clean-protocols.js
@@ -1,10 +1,10 @@
 import assert from 'assert';
-import helper from '../../../client/helpers/clean-protocols';
+import cleanProtocols from '../../../client/helpers/clean-protocols';
 
 describe('clean-protocols', () => {
 
   it('removes unused establishments from protocols', () => {
-    const project = {
+    const state = {
       title: 'Test project',
       objectives: [],
       protocols: [
@@ -18,7 +18,7 @@ describe('clean-protocols', () => {
         }
       ]
     };
-    const props = {
+    const changed = {
       establishments: [
         { 'establishment-name': 'University of Croydon' }
       ]
@@ -26,7 +26,7 @@ describe('clean-protocols', () => {
     const establishment = {
       name: 'University of Cheese'
     };
-    assert.deepEqual(helper(project, props, establishment), {
+    assert.deepEqual(cleanProtocols({ state, changed, establishment }), {
       title: 'Test project',
       objectives: [],
       establishments: [
@@ -45,11 +45,11 @@ describe('clean-protocols', () => {
   });
 
   it('does not throw an error if project has no objectives', () => {
-    const project = {
+    const state = {
       title: 'Test project',
       protocols: []
     };
-    const props = {
+    const changed = {
       establishments: [
         { 'establishment-name': 'University of Croydon' }
       ]
@@ -57,11 +57,47 @@ describe('clean-protocols', () => {
     const establishment = {
       name: 'University of Cheese'
     };
-    assert.deepEqual(helper(project, props, establishment), {
+    assert.deepEqual(cleanProtocols({ state, changed, establishment }), {
       title: 'Test project',
       protocols: [],
       establishments: [
         { 'establishment-name': 'University of Croydon' }
+      ]
+    });
+  });
+
+  it('removes species from protocols when they are removed from the project', () => {
+    const savedState = {
+      title: 'Test project',
+      species: ['mice', 'rats'],
+      protocols: [
+        {
+          species: ['mice', 'rats']
+        }
+      ]
+    };
+    const state = {
+      title: 'Test project',
+      species: ['mice'],
+      protocols: [
+        {
+          species: ['mice', 'rats']
+        }
+      ]
+    };
+    const changed = {
+      species: ['mice']
+    };
+    const establishment = {
+      name: 'University of Cheese'
+    };
+    assert.deepEqual(cleanProtocols({ state, savedState, changed, establishment }), {
+      title: 'Test project',
+      species: ['mice'],
+      protocols: [
+        {
+          species: ['mice']
+        }
       ]
     });
   });


### PR DESCRIPTION
When saving changes to the project level species, this will now strip the species from `protocol.species` list, but leave the `protocol.speciesDetails` intact.

This will render a changed badge immediately after save against the Protocols section and the relevant protocols.