### PR TITLE
Add error type to apply existing error style

### DIFF
--- a/client/components/download-link/renderers/docx-renderer.js
+++ b/client/components/download-link/renderers/docx-renderer.js
@@ -370,6 +370,10 @@ export default (application, sections, values, updateImageDimensions) => {
         parent.addParagraph(paragraph);
         break;
 
+      case 'error':
+        parent.createParagraph(getContent(node)).style('error');
+        break;
+
       default:
         // if there is no matching type then it's probably a denormalised text node with no wrapping paragraph
         // attempt to render with the node wrapped in a paragraph


### PR DESCRIPTION
Add error case to add error styling to word doc

<img width="564" alt="Screenshot 2022-09-21 at 17 48 05" src="https://user-images.githubusercontent.com/61828376/191564081-2dd94dd1-f33b-4b78-8c50-1205d9023854.png">