### PR TITLE
Fix syncing bugs with new projects filled out in an odd order

### DIFF
--- a/client/actions/projects.js
+++ b/client/actions/projects.js
@@ -282,6 +282,8 @@ const syncProject = (dispatch, getState) => {
 
   const patch = jsondiff.diff(state.savedProject, project);
   if (!patch) {
+    dispatch(updateSavedProject(project));
+    dispatch(doneSyncing());
     return Promise.resolve();
   }
 

--- a/client/helpers/clean-protocols.js
+++ b/client/helpers/clean-protocols.js
@@ -19,6 +19,9 @@ export default function cleanProtocols({ state, savedState, changed = {}, establ
     const removedProjectSpecies = difference(savedState.species, changed.species);
 
     project.protocols.forEach(protocol => {
+      if (!Array.isArray(protocol.species)) {
+        return;
+      }
       protocol.species = protocol.species.filter(species => !removedProjectSpecies.includes(species));
     });
   }


### PR DESCRIPTION
# Protocol filters

If you add a protocol without filling out any details, and then go back to the introductory details and change the species then an error is thrown because it tries to filter `protocol.species` when they're not defined.

# Empty duration field

When the duration field is empty it gets a value set to `{ years: undefined, months: undefined }` which `isEqual` considers to be different to `{}`, but then `diff` returns no difference because it considers them to be equivalent.

When the patch is undefined then no request is sent to the server, but `doneSyncing` is never called, so all future syncs are blocked. Also need to set the saved state to the local state in this case, so that a "change" (not actually a change) in the duration value field does not repeatedly cause attempts to sync.