### PR TITLE
ASL-4046 Reusable steps

### DIFF
--- a/assets/scss/projects.scss
+++ b/assets/scss/projects.scss
@@ -985,6 +985,38 @@ html.modal-open, html.modal-open body {
         background: $white;
       }
     }
+
+    .review-step {
+      margin-bottom: $govuk-gutter;
+
+      .expandable {
+        > .header {
+          background-color: $mid-grey;
+
+          h3 {
+            margin-bottom: 10px;
+          }
+
+          .title:before {
+            content: none;
+          }
+
+          &:hover {
+            background-color: #f3f2f1;
+          }
+        }
+
+        > .content {
+          padding: $govuk-gutter-half;
+          background: $mid-grey;
+
+          > .review {
+            background-color: $white;
+            padding: $govuk-gutter-half;
+          }
+        }
+      }
+    }
   }
 
   .accordion {

--- a/client/actions/projects.js
+++ b/client/actions/projects.js
@@ -11,6 +11,7 @@ import sendMessage from './messaging';
 import { getConditions } from '../helpers';
 import cleanProtocols from '../helpers/clean-protocols';
 import sha from 'sha.js';
+import { keyBy } from 'lodash';
 
 const CONDITIONS_FIELDS = ['conditions', 'retrospectiveAssessment'];
 
@@ -87,6 +88,17 @@ export function updateProject(project) {
   return {
     type: types.UPDATE_PROJECT,
     project
+  };
+}
+
+export function saveReusableSteps(reusableSteps) {
+  return (dispatch, getState) => {
+    const state = getState();
+    const newState = cloneDeep(state.project);
+    const updatedReusableSteps = keyBy(reusableSteps, 'id');
+    newState.reusableSteps = {...newState.reusableSteps, ...updatedReusableSteps};
+    dispatch(updateProject(newState));
+    return debouncedSyncConditions(dispatch, getState);
   };
 }
 

--- a/client/actions/projects.js
+++ b/client/actions/projects.js
@@ -98,7 +98,7 @@ export function saveReusableSteps(reusableSteps) {
     const updatedReusableSteps = keyBy(reusableSteps, 'id');
     newState.reusableSteps = {...newState.reusableSteps, ...updatedReusableSteps};
     dispatch(updateProject(newState));
-    return debouncedSyncConditions(dispatch, getState);
+    return debouncedSyncProject(dispatch, getState);
   };
 }
 

--- a/client/components/application-summary.js
+++ b/client/components/application-summary.js
@@ -230,6 +230,9 @@ const ApplicationSummary = () => {
                   subsections.map(key => {
                     const subsection = section.subsections[key];
                     const fields = Object.values(fieldsBySection[key] || []);
+                    if (key === 'protocols') {
+                      fields.push('reusableSteps');
+                    }
                     if (subsection.repeats) {
                       fields.push(subsection.repeats);
                     }

--- a/client/components/review.js
+++ b/client/components/review.js
@@ -44,7 +44,7 @@ class Review extends React.Component {
     }
 
     return (
-      <div className="review">
+      <div className={this.props.className || 'review'}>
         {
           (!isGranted || showGrantedLabel) && <h3>{review || label}</h3>
         }

--- a/client/components/side-nav.js
+++ b/client/components/side-nav.js
@@ -28,6 +28,7 @@ function getFieldsForSection(section, project) {
     fields.push(section.repeats);
   }
   if (section.name === 'protocols') {
+    fields.push('reusableSteps');
     return fields.filter(f => f !== 'title');
   }
   return fields;
@@ -53,10 +54,11 @@ export default function SideNav(props) {
           .sort((a, b) => !isGranted ? true : sections[a].granted.order - sections[b].granted.order)
           .map(key => {
             const section = sections[key];
+            const fieldsForSection = getFieldsForSection(section, project);
             if (section.subsections) {
               const open = !!(activeSection && section.subsections[activeSection]);
               const title = <Fragment>
-                <ChangedBadge fields={getFieldsForSection(section, project)} noLabel />
+                <ChangedBadge fields={fieldsForSection} noLabel />
                 <span className="indent">{section.subtitle || section.title}</span>
               </Fragment>;
               return (
@@ -74,7 +76,7 @@ export default function SideNav(props) {
             }
             return (
               <NavLink key={key} to={`/${key}`}>
-                <ChangedBadge fields={getFieldsForSection(section, project)} notLabel />
+                <ChangedBadge fields={fieldsForSection} notLabel />
                 <h3>
                   {
                     isGranted

--- a/client/helpers/reusable-steps.js
+++ b/client/helpers/reusable-steps.js
@@ -1,0 +1,33 @@
+export const hydrateSteps = (protocols, steps, reusableSteps) => {
+
+  const reusableStepsInAllProtocols =
+    (protocols || [])
+      .flatMap((protocol, index) => (protocol.steps || [])
+        .filter(step => !!step.reusableStepId)
+        .map(step => {
+          return { reusableStepId: step.reusableStepId, protocolIndex: index + 1 };
+        })
+      )
+      .reduce((map, reusableStep) => {
+        if (!map[reusableStep.reusableStepId]) {
+          map[reusableStep.reusableStepId] = [];
+        }
+        map[reusableStep.reusableStepId].push(reusableStep.protocolIndex);
+        return map;
+      }, {});
+
+  const hydratedSteps = (steps || []).filter(Boolean)
+    .map(step => {
+      if (step.reusableStepId) {
+        const reusableStep = {
+          ...reusableSteps[step.reusableStepId],
+          usedInProtocols: reusableStepsInAllProtocols[step.reusableStepId],
+          reusedStep: true
+        };
+        return { ...reusableStep, ...step };
+      }
+      return step;
+    });
+
+  return [hydratedSteps, Object.values(reusableSteps)];
+};

--- a/client/helpers/steps.js
+++ b/client/helpers/steps.js
@@ -1,21 +1,23 @@
 import {Value} from 'slate';
 import React from 'react';
+import { uniq } from 'lodash';
 
 export const hydrateSteps = (protocols, steps, reusableSteps) => {
 
   const reusableStepsInAllProtocols =
     (protocols || [])
+      .filter(protocol => !protocol.deleted)
       .flatMap((protocol, index) => (protocol.steps || [])
         .filter(step => !!step.reusableStepId)
         .map(step => {
-          return { reusableStepId: step.reusableStepId, protocolIndex: index + 1 };
+          return { reusableStepId: step.reusableStepId, protocolIndex: index + 1, protocolId: protocol.id };
         })
       )
       .reduce((map, reusableStep) => {
         if (!map[reusableStep.reusableStepId]) {
           map[reusableStep.reusableStepId] = [];
         }
-        map[reusableStep.reusableStepId].push(reusableStep.protocolIndex);
+        map[reusableStep.reusableStepId].push({ protocolNumber: reusableStep.protocolIndex, protocolId: reusableStep.protocolId });
         return map;
       }, {});
 
@@ -24,7 +26,7 @@ export const hydrateSteps = (protocols, steps, reusableSteps) => {
       if (step.reusableStepId) {
         const reusableStep = {
           ...reusableSteps[step.reusableStepId],
-          usedInProtocols: reusableStepsInAllProtocols[step.reusableStepId],
+          usedInProtocols: uniq(reusableStepsInAllProtocols[step.reusableStepId]),
           reusedStep: true
         };
         return { ...reusableStep, ...step };

--- a/client/helpers/steps.js
+++ b/client/helpers/steps.js
@@ -56,3 +56,8 @@ export const getStepTitle = title => {
     ? value.document.text
     : untitled;
 };
+
+export const reusableStepFieldKeys = (protocol) =>
+  (protocol.steps || [])
+    .filter(step => step.reusableStepId)
+    .map(reusableStep => `reusableSteps.${reusableStep.reusableStepId}`);

--- a/client/helpers/steps.js
+++ b/client/helpers/steps.js
@@ -1,3 +1,6 @@
+import {Value} from 'slate';
+import React from 'react';
+
 export const hydrateSteps = (protocols, steps, reusableSteps) => {
 
   const reusableStepsInAllProtocols =
@@ -30,4 +33,24 @@ export const hydrateSteps = (protocols, steps, reusableSteps) => {
     });
 
   return [hydratedSteps, Object.values(reusableSteps)];
+};
+
+export const getStepTitle = title => {
+  const untitled = <em>Untitled step</em>;
+  if (!title) {
+    return untitled;
+  }
+
+  if (typeof title === 'string') {
+    try {
+      title = JSON.parse(title);
+    } catch (e) {
+      return untitled;
+    }
+  }
+
+  const value = Value.fromJSON(title);
+  return value.document.text && value.document.text !== ''
+    ? value.document.text
+    : untitled;
 };

--- a/client/pages/sections/granted/protocol-steps.js
+++ b/client/pages/sections/granted/protocol-steps.js
@@ -1,8 +1,7 @@
 import React, { Fragment } from 'react';
-import { Value } from 'slate';
 import Review from '../../../components/review';
 import ReviewFields from '../../../components/review-fields';
-import {hydrateSteps} from '../../../helpers/reusable-steps';
+import {getStepTitle, hydrateSteps} from '../../../helpers/steps';
 
 const Step = ({ id, index, fields, prefix, ...props }) => {
   return (
@@ -44,25 +43,6 @@ const Step = ({ id, index, fields, prefix, ...props }) => {
 
 const Steps = ({ values, fields, pdf, prefix, project }) => {
   const [ steps ] = hydrateSteps(project.protocols, values.steps, project.reusableSteps || {});
-  const getStepTitle = title => {
-    const untitled = <em>Untitled step</em>;
-    if (!title) {
-      return untitled;
-    }
-
-    if (typeof title === 'string') {
-      try {
-        title = JSON.parse(title);
-      } catch (e) {
-        return untitled;
-      }
-    }
-
-    const value = Value.fromJSON(title);
-    return value.document.text && value.document.text !== ''
-      ? value.document.text
-      : untitled;
-  };
 
   return (
     <div className="granted-steps">

--- a/client/pages/sections/granted/protocol-steps.js
+++ b/client/pages/sections/granted/protocol-steps.js
@@ -2,12 +2,13 @@ import React, { Fragment } from 'react';
 import { Value } from 'slate';
 import Review from '../../../components/review';
 import ReviewFields from '../../../components/review-fields';
+import {hydrateSteps} from '../../../helpers/reusable-steps';
 
 const Step = ({ id, index, fields, prefix, ...props }) => {
   return (
     <div className="granted-step" id={id}>
       <div className="header">
-        <h2 className="step-number">Step {index + 1} <span className="smaller">({ props.optional ? 'Optional' : 'Mandatory'})</span></h2>
+        <h2 className="step-number">Step {index + 1} {props.reference && (<Fragment>: { props.reference }</Fragment>)} <span className="smaller">({ props.optional ? 'Optional' : 'Mandatory'})</span></h2>
         <Review
           {...fields.find(f => f.name === 'title')}
           label=""
@@ -41,7 +42,8 @@ const Step = ({ id, index, fields, prefix, ...props }) => {
   );
 };
 
-const Steps = ({ values, fields, pdf, prefix }) => {
+const Steps = ({ values, fields, pdf, prefix, project }) => {
+  const [ steps ] = hydrateSteps(project.protocols, values.steps, project.reusableSteps || {});
   const getStepTitle = title => {
     const untitled = <em>Untitled step</em>;
     if (!title) {
@@ -73,10 +75,10 @@ const Steps = ({ values, fields, pdf, prefix }) => {
             <h3 id="step-index">Index of steps</h3>
             <ol>
               {
-                values.steps.map((step, index) => (
+                steps.map((step, index) => (
                   <li key={step.id} className="step-index-item">
                     <span>{index + 1}. </span>
-                    <a href={`#${step.id}`}>{getStepTitle(step.title)}</a><br />
+                    <a href={`#${step.id}`}>{step.reference || getStepTitle(step.title)}</a><br />
                     <span>{step.optional ? 'Optional' : 'Mandatory'}</span>
                   </li>
                 ))
@@ -87,7 +89,7 @@ const Steps = ({ values, fields, pdf, prefix }) => {
         )
       }
       {
-        values.steps.map((step, index) => <Step key={step.id} {...step} index={index} fields={fields} pdf={pdf} prefix={`${prefix}steps.${step.id}.`} />)
+        steps.map((step, index) => <Step key={step.id} {...step} index={index} fields={fields} pdf={pdf} prefix={`${prefix}steps.${step.id}.`} />)
       }
     </div>
   );

--- a/client/pages/sections/protocols/protocol-sections.js
+++ b/client/pages/sections/protocols/protocol-sections.js
@@ -15,6 +15,7 @@ import ReorderedBadge from '../../../components/reordered-badge';
 import { filterSpeciesByActive } from './animals';
 
 import { keepAlive } from '../../../actions/session';
+import { reusableStepFieldKeys } from '../../../helpers/steps';
 
 class ProtocolSections extends PureComponent {
   state = {
@@ -98,7 +99,7 @@ class ProtocolSections extends PureComponent {
             <Fragment>
               <NewProtocolBadge id={values.id} />
               <ReorderedBadge id={values.id} />
-              <ChangedBadge fields={[`protocols.${values.id}`]} protocolId={values.id} />
+              <ChangedBadge fields={[`protocols.${values.id}`, ...reusableStepFieldKeys(values)]} protocolId={values.id} />
             </Fragment>
           )
         }

--- a/client/pages/sections/protocols/sections.js
+++ b/client/pages/sections/protocols/sections.js
@@ -166,12 +166,14 @@ const mapStateToProps = ({
     showConditions,
     isGranted,
     isFullApplication
-  }
+  },
+  project
 }, { sections }) => ({
   schemaVersion,
   showConditions,
   isGranted,
   isFullApplication,
+  project,
   // show all sections for legacy
   sections: isGranted && !isFullApplication && schemaVersion !== 0
     ? pickBy(sections, section => section.granted)

--- a/client/pages/sections/protocols/sections.js
+++ b/client/pages/sections/protocols/sections.js
@@ -19,6 +19,7 @@ import Animals from './animals';
 import LegacyAnimals from './legacy-animals';
 import Conditions from '../../../components/conditions/protocol-conditions';
 import ChangedBadge from '../../../components/changed-badge';
+import {reusableStepFieldKeys} from '../../../helpers/steps';
 
 const getSection = (section, props) => {
   const isFullApplicationPdf = props.isFullApplication && props.pdf;
@@ -79,7 +80,9 @@ const getOpenSection = (protocolState, editable, sections) => {
 
 const getFieldKeys = (section, values) => {
   if (section.repeats) {
-    return [`protocols.${values.id}.${section.repeats}`];
+    // If steps then add the reusable steps to the field keys
+    const additionalReusableStepKeys = section.repeats === 'steps' ? reusableStepFieldKeys(values): [];
+    return [`protocols.${values.id}.${section.repeats}`, ...additionalReusableStepKeys];
   }
   const flattenedFields = flattenReveals(section.fields || [], values);
   if (section.repeats) {

--- a/client/pages/sections/protocols/sections.js
+++ b/client/pages/sections/protocols/sections.js
@@ -81,7 +81,7 @@ const getOpenSection = (protocolState, editable, sections) => {
 const getFieldKeys = (section, values) => {
   if (section.repeats) {
     // If steps then add the reusable steps to the field keys
-    const additionalReusableStepKeys = section.repeats === 'steps' ? reusableStepFieldKeys(values): [];
+    const additionalReusableStepKeys = section.repeats === 'steps' ? reusableStepFieldKeys(values) : [];
     return [`protocols.${values.id}.${section.repeats}`, ...additionalReusableStepKeys];
   }
   const flattenedFields = flattenReveals(section.fields || [], values);

--- a/client/pages/sections/protocols/steps.js
+++ b/client/pages/sections/protocols/steps.js
@@ -190,7 +190,7 @@ class Step extends Component {
           <p className="control-panel">
             <Button onClick={this.saveStep}>Save step</Button>
             {
-              length > 1 && <Button className="link" onClick={this.removeItem}>Remove step</Button>
+              length > 1 && <Button className="link" onClick={this.removeItem}>{editingReusableStep ? 'Remove this step from this protocol' : 'Remove step'}</Button>
             }
             {
               values.existingValues && <Button className="link" onClick={this.cancelItem}>Cancel</Button>

--- a/client/pages/sections/protocols/steps.js
+++ b/client/pages/sections/protocols/steps.js
@@ -1,17 +1,31 @@
-import React, { Component, Fragment, createRef } from 'react';
-import { useParams } from 'react-router';
+import React, {Component, createRef, Fragment, useState} from 'react';
+import {useParams} from 'react-router';
 
 import classnames from 'classnames';
-import { Button } from '@ukhomeoffice/react-components';
+import {Button, Warning} from '@ukhomeoffice/react-components';
 
 import isUndefined from 'lodash/isUndefined';
-import pickBy from 'lodash/pickBy';
+import {isEqual, pickBy, uniqBy, uniq} from 'lodash';
 
 import ReviewFields from '../../../components/review-fields';
 import Repeater from '../../../components/repeater';
 import Fieldset from '../../../components/fieldset';
 import NewComments from '../../../components/new-comments';
 import ChangedBadge from '../../../components/changed-badge';
+import {v4 as uuid} from 'uuid';
+import Review from '../../../components/review';
+
+function isNewStep(step) {
+  return step && isEqual(Object.keys(step).filter(a => a !== 'addExisting'), ['id']);
+}
+
+function renderProtocols(values) {
+  let usedInProtocols = uniq(values.usedInProtocols || []);
+  if (usedInProtocols.length < 2) {
+    return usedInProtocols;
+  }
+  return `${usedInProtocols.slice(0, usedInProtocols.length - 1).join(',')} and ${usedInProtocols[usedInProtocols.length - 1]}`;
+}
 
 class Step extends Component {
   constructor(options) {
@@ -45,13 +59,32 @@ class Step extends Component {
 
   saveStep = e => {
     e.preventDefault();
-    this.setCompleted(true);
+    this.props.updateItem({ completed: true, existingValues: undefined });
     this.scrollToStep();
   }
 
   editStep = e => {
     e.preventDefault();
     this.setCompleted(false);
+    this.scrollToStep();
+  }
+
+  editThisStep = e => {
+    e.preventDefault();
+    this.props.updateItem({ completed: false, reference: `${this.props.values.reference} (edited)`, reusableStepId: null, existingValues: this.props.values });
+    this.scrollToStep();
+  }
+
+  editReusableStep = e => {
+    e.preventDefault();
+    this.props.updateItem({ completed: false, existingValues: this.props.values });
+    this.scrollToStep();
+  }
+
+  cancelItem = e => {
+    e.preventDefault();
+    let updateItem = {...this.props.values.existingValues, existingValues: null};
+    this.props.updateItem(updateItem);
     this.scrollToStep();
   }
 
@@ -81,7 +114,21 @@ class Step extends Component {
   }
 
   render() {
-    const { prefix, index, fields, values, updateItem, length, editable, deleted, isReviewStep, protocol, newComments } = this.props;
+    const {
+      prefix,
+      index,
+      fields,
+      values,
+      updateItem,
+      parentUpdateItem,
+      length,
+      editable,
+      deleted,
+      isReviewStep,
+      protocol,
+      newComments,
+      reusableSteps
+    } = this.props;
 
     const re = new RegExp(`^steps.${values.id}\\.`);
     const relevantComments = Object.values(
@@ -89,13 +136,14 @@ class Step extends Component {
     ).reduce((total, comments) => total + (comments || []).length, 0);
 
     const completed = !editable || values.completed;
-    return (
+    let editingReusableStep = !completed && values.existingValues && values.reusableStepId;
+    const step = <>
       <section
         className={classnames('step', { completed, editable })}
         ref={this.step}
       >
-        <NewComments comments={relevantComments} />
-        <ChangedBadge fields={[ prefix.substr(0, prefix.length - 1) ]} protocolId={protocol.id} />
+        <NewComments comments={relevantComments}/>
+        <ChangedBadge fields={[prefix.substr(0, prefix.length - 1)]} protocolId={protocol.id}/>
         <Fragment>
           {
             editable && completed && !deleted && (
@@ -114,13 +162,14 @@ class Step extends Component {
           <h3>
             {`Step ${index + 1}`}
             {
-              completed && !isUndefined(values.optional) && <span className="light smaller">{` (${values.optional === true ? 'optional' : 'mandatory'})`}</span>
+              completed && !isUndefined(values.optional) &&
+              <span className="light smaller">{` (${values.optional === true ? 'optional' : 'mandatory'})`}</span>
             }
           </h3>
           {
             completed && values.title && (
               <ReviewFields
-                fields={[ fields.find(f => f.name === 'title') ]}
+                fields={[fields.find(f => f.name === 'title')]}
                 values={{ title: values.title }}
                 prefix={this.props.prefix}
                 editLink={`0#${this.props.prefix}`}
@@ -131,18 +180,42 @@ class Step extends Component {
           }
         </Fragment>
         {
+          editingReusableStep && (<Warning>{`You are editing all instances of this step. The changes will also appear in protocols ${(renderProtocols(values))}.`}</Warning>)
+        }
+        {
+          !completed && values.existingValues && !values.reusableStepId && (<Warning>{`You are editing only this instance of this step. Changes made to this step will not appear where the '${values.existingValues.reference}' step is reused on protocols ${(renderProtocols(values))}.`}</Warning>)
+        }
+        {
           !completed && !deleted
             ? <Fragment>
-              <Fieldset
+              {!(editingReusableStep) ? <Fieldset
                 fields={fields}
                 prefix={prefix}
                 onFieldChange={(key, value) => updateItem({ [key]: value })}
                 values={values}
-              />
+              /> : <Fragment>
+                <Fieldset
+                  fields={fields.filter(f => f.name !== 'reusable')}
+                  prefix={prefix}
+                  onFieldChange={(key, value) => updateItem({ [key]: value })}
+                  values={values}
+                />
+                <Review
+                  {...fields.find(f => f.name === 'reusable')}
+                  value={values.existingValues.reusable}
+                  readonly={true}
+                  className={'reusable'}
+                />
+                <Warning>You cannot change this answer when editing all instances of this step.</Warning>
+              </Fragment>
+              }
               <p className="control-panel">
                 <Button onClick={this.saveStep}>Save step</Button>
                 {
                   length > 1 && <Button className="link" onClick={this.removeItem}>Remove step</Button>
+                }
+                {
+                  values.existingValues && <Button className="link" onClick={this.cancelItem}>Cancel</Button>
                 }
               </p>
             </Fragment>
@@ -156,36 +229,185 @@ class Step extends Component {
                 protocolId={protocol.id}
               />
               {
-                editable && !deleted && <a href="#" onClick={this.editStep}>Edit step</a>
+                !values.reusable && editable && !deleted && <a href="#" onClick={this.editStep}>Edit step</a>
+              }
+              {
+                values.reusable && editable && !deleted && (<><a href="#" onClick={this.editThisStep}>Edit just this step</a> | <a href="#" onClick={this.editReusableStep}>Edit every instance of this step</a></>)
               }
             </div>
         }
       </section>
-    );
+    </>;
+
+    if (isNewStep(values) && reusableSteps.length > 0) {
+      const onSaveSelection = (selectedSteps) => {
+        // Replace current step with selected
+        const mappedSteps = (this.props.protocol.steps || []).flatMap(step => {
+          if (step.id === values.id) {
+            return selectedSteps.map(selectedStep => {
+              return { id: uuid(), reusableStepId: selectedStep };
+            });
+          }
+          return [step];
+        });
+        parentUpdateItem({ steps: mappedSteps });
+      };
+
+      const fields = [{
+        name: 'addExisting',
+        label: 'Add step',
+        type: 'radio',
+        className: 'smaller',
+        options: [
+          {
+            label: 'Create a new step',
+            value: false,
+            reveal: {
+              component: step
+            }
+          },
+          {
+            label: 'Select steps used in other protocols',
+            value: true,
+            reveal: {
+              component: <StepSelector reusableSteps={reusableSteps} values={values} onSaveSelection={onSaveSelection} onCancel={this.removeItem} length={length} />
+            }
+          }
+        ],
+        inline: false
+      }];
+
+      return (<Fragment>
+        <Fieldset
+          fields={fields}
+          prefix={`${values.id}-add-step`}
+          onFieldChange={(key, value) => {
+            updateItem({ [key]: value });
+          }}
+          values={values}
+        />
+      </Fragment>);
+    }
+
+    return step;
   }
 }
 
+const StepSelector = ({ reusableSteps, values, onSaveSelection, length, onCancel }) => {
+  const [selectedSteps, setSelectedSteps] = useState([]);
+  const selectStepFields = [{
+    name: 'select-steps',
+    label: 'Select step',
+    type: 'checkbox',
+    className: 'smaller',
+    options: uniqBy(reusableSteps, 'step.id')
+      .map(reusableStep => {
+        return {
+          label: reusableStep.step.reference,
+          value: reusableStep.step.id
+        };
+      })
+  }];
+  const saveSelectionHandler = (e) => {
+    onSaveSelection(selectedSteps);
+  };
+
+  return <Fragment>
+    <Fieldset
+      fields={selectStepFields}
+      prefix={`${values.id}-select-steps`}
+      onFieldChange={(key, value) => {
+        setSelectedSteps(value);
+      }}
+      values={values}
+    />
+    <p className="control-panel">
+      <Button className={classnames('block', 'save-selection')} onClick={saveSelectionHandler}>Add steps to protocol</Button>
+      {
+        length > 1 && <Button className="link" onClick={onCancel}>Cancel</Button>
+      }
+    </p>
+  </Fragment>;
+};
+
 export default function Steps({ values, prefix, updateItem, editable, ...props }) {
   const isReviewStep = parseInt(useParams().step, 10) === 1;
+  const reusableSteps = (props.protocols || [])
+    .flatMap(protocol => (protocol.reusableSteps || [])
+      .map((step, index) => {
+        return { protocol, step, protocolNumber: index + 1 };
+      })
+    );
+
+  const reusableStepsInAllProtocols =
+    (props.protocols || [])
+      .flatMap((protocol, index) => (protocol.steps || [])
+        .filter(step => !!step.reusableStepId)
+        .map(step => {
+          return { reusableStepId: step.reusableStepId, protocolIndex: index + 1 };
+        })
+      )
+      .reduce((map, reusableStep) => {
+        if (!map[reusableStep.reusableStepId]) {
+          map[reusableStep.reusableStepId] = [];
+        }
+        map[reusableStep.reusableStepId].push(reusableStep.protocolIndex);
+        return map;
+      }, {});
+
+  const allReusableStepsById = reusableSteps
+    .reduce((map, stepWithProtocol) => {
+      map[stepWithProtocol.step.id] = stepWithProtocol;
+      return map;
+    }, {});
+
+  const steps = (values.steps || []).filter(Boolean)
+    .map(step => {
+      if (step.reusableStepId) {
+        const reusableStep = {...allReusableStepsById[step.reusableStepId]?.step, usedInProtocols: reusableStepsInAllProtocols[step.reusableStepId]};
+        return { ...step, ...reusableStep };
+      }
+      return step;
+    });
+
+  const lastStepIsNew = isNewStep(steps[steps.length - 1]);
+
   return (
     <div className="steps">
       <p className="grey">{props.hint}</p>
-      <br />
+      <br/>
       <Repeater
         type="steps"
         singular="step"
         prefix={prefix}
-        items={(values.steps || []).filter(Boolean)}
-        onSave={steps => updateItem({ steps })}
-        addAnother={!props.pdf && !values.deleted && editable}
-        { ...props }
+        items={steps}
+        onSave={steps => {
+          // Extract reusable to own field
+          const reusableSteps = steps.filter(step => step.reusable)
+            .map(reusableStep => {
+              return { ...reusableStep };
+            });
+
+          const mappedSteps = steps.map(step => {
+            if (step.reusable) {
+              return { id: step.id, reusableStepId: step.id };
+            }
+            return step;
+          });
+
+          updateItem({ steps: mappedSteps, reusableSteps });
+        }}
+        addAnother={!props.pdf && !values.deleted && editable && !lastStepIsNew}
+        {...props}
       >
         <Step
           editable={editable}
           deleted={values.deleted}
           isReviewStep={isReviewStep}
           protocol={values}
-          { ...props }
+          reusableSteps={reusableSteps}
+          {...props}
+          parentUpdateItem={updateItem}
         />
       </Repeater>
     </div>

--- a/client/pages/sections/protocols/steps.js
+++ b/client/pages/sections/protocols/steps.js
@@ -19,7 +19,7 @@ import {saveReusableSteps} from '../../../actions/projects';
 import Expandable from '../../../components/expandable';
 
 function isNewStep(step) {
-  return step && isEqual(Object.keys(step).filter(a => a !== 'addExisting'), ['id']);
+  return step && (isEqual(Object.keys(step).filter(a => a !== 'addExisting'), ['id']) || !isUndefined(step.addExisting));
 }
 
 function renderUsedInProtocols(values) {
@@ -66,7 +66,7 @@ class Step extends Component {
 
   saveStep = e => {
     e.preventDefault();
-    this.props.updateItem({ completed: true, existingValues: undefined });
+    this.props.updateItem({ completed: true, existingValues: undefined, addExisting: undefined });
     this.scrollToStep();
   }
 
@@ -218,8 +218,8 @@ class Step extends Component {
         className={classnames('step', { completed, editable })}
         ref={this.step}
       >
-        <NewComments comments={relevantComments}/>
-        <ChangedBadge fields={[prefix.substr(0, prefix.length - 1)]} protocolId={protocol.id}/>
+        <NewComments comments={relevantComments} />
+        <ChangedBadge fields={[ prefix.substr(0, prefix.length - 1) ]} protocolId={protocol.id} />
         <Fragment>
           {
             editable && completed && !deleted && (
@@ -308,8 +308,8 @@ class Step extends Component {
     if (isReviewStep) {
       return (
         <section className={'review-step'}>
-          <NewComments comments={relevantComments}/>
-          <ChangedBadge fields={[prefix.substr(0, prefix.length - 1)]} protocolId={protocol.id}/>
+          <NewComments comments={relevantComments} />
+          <ChangedBadge fields={[ prefix.substr(0, prefix.length - 1) ]} protocolId={protocol.id} />
           <Expandable expanded={this.state.expanded} onHeaderClick={this.toggleExpanded}>
             <Fragment>
               <p className={'toggles float-right'}>

--- a/client/pages/sections/protocols/steps.js
+++ b/client/pages/sections/protocols/steps.js
@@ -22,7 +22,7 @@ function isNewStep(step) {
   return step && isEqual(Object.keys(step).filter(a => a !== 'addExisting'), ['id']);
 }
 
-function renderProtocols(values) {
+function renderUsedInProtocols(values) {
   let usedInProtocols = uniq(values.usedInProtocols || []);
   if (usedInProtocols.length < 2) {
     return usedInProtocols;
@@ -245,11 +245,11 @@ class Step extends Component {
         </Fragment>
         {
           editingReusableStep && (
-            <Warning>{`You are editing all instances of this step. The changes will also appear in protocols ${(renderProtocols(values))}.`}</Warning>)
+            <Warning>{`You are editing all instances of this step. The changes will also appear in protocols ${(renderUsedInProtocols(values))}.`}</Warning>)
         }
         {
           !completed && values.existingValues && !values.reusableStepId && (
-            <Warning>{`You are editing only this instance of this step. Changes made to this step will not appear where the '${values.existingValues.reference}' step is reused on protocols ${(renderProtocols(values))}.`}</Warning>)
+            <Warning>{`You are editing only this instance of this step. Changes made to this step will not appear where the '${values.existingValues.reference}' step is reused on protocols ${(renderUsedInProtocols(values))}.`}</Warning>)
         }
         {stepContent}
       </section>

--- a/client/pages/sections/protocols/steps.js
+++ b/client/pages/sections/protocols/steps.js
@@ -29,6 +29,8 @@ function renderUsedInProtocols(protocolIndexes) {
   return `${protocolIndexes.slice(0, protocolIndexes.length - 1).join(',')} and ${protocolIndexes[protocolIndexes.length - 1]}`;
 }
 
+const changeFields = (step, prefix) => step.reusable ? [ `reusableSteps.${step.reusableStepId}` ] : [ prefix.substr(0, prefix.length - 1) ];
+
 class Step extends Component {
   state = {
     expanded: false
@@ -125,7 +127,6 @@ class Step extends Component {
 
   render() {
     const {
-      prefix,
       index,
       fields,
       values,
@@ -139,6 +140,7 @@ class Step extends Component {
       newComments,
       reusableSteps
     } = this.props;
+    const changeFieldPrefix = values.reusableStepId ? `reusableSteps.${values.reusableStepId}.` : this.props.prefix;
 
     const re = new RegExp(`^steps.${values.id}\\.`);
     const relevantComments = Object.values(
@@ -152,7 +154,7 @@ class Step extends Component {
         <ReviewFields
           fields={[fields.find(f => f.name === 'title')]}
           values={{ title: values.title }}
-          prefix={this.props.prefix}
+          prefix={changeFieldPrefix}
           editLink={`0#${this.props.prefix}`}
           protocolId={protocol.id}
           readonly={!isReviewStep}
@@ -164,13 +166,13 @@ class Step extends Component {
         ? <Fragment>
           {!(editingReusableStep) ? <Fieldset
             fields={fields}
-            prefix={prefix}
+            prefix={changeFieldPrefix}
             onFieldChange={(key, value) => updateItem({ [key]: value })}
             values={values}
           /> : <Fragment>
             <Fieldset
               fields={fields.filter(f => f.name !== 'reusable')}
-              prefix={prefix}
+              prefix={changeFieldPrefix}
               onFieldChange={(key, value) => updateItem({ [key]: value })}
               values={values}
             />
@@ -197,7 +199,7 @@ class Step extends Component {
           <ReviewFields
             fields={fields.filter(f => f.name !== 'title')}
             values={values}
-            prefix={this.props.prefix}
+            prefix={changeFieldPrefix}
             editLink={`0#${this.props.prefix}`}
             readonly={!isReviewStep}
             protocolId={protocol.id}
@@ -218,7 +220,7 @@ class Step extends Component {
         ref={this.step}
       >
         <NewComments comments={relevantComments} />
-        <ChangedBadge fields={[ prefix.substr(0, prefix.length - 1) ]} protocolId={protocol.id} />
+        <ChangedBadge fields={changeFields(values, changeFieldPrefix)} protocolId={protocol.id} />
         <Fragment>
           {
             editable && completed && !deleted && (
@@ -302,7 +304,7 @@ class Step extends Component {
       return (
         <section className={'review-step'}>
           <NewComments comments={relevantComments} />
-          <ChangedBadge fields={[ prefix.substr(0, prefix.length - 1) ]} protocolId={protocol.id} />
+          <ChangedBadge fields={changeFields(values, changeFieldPrefix)} protocolId={protocol.id} />
           <Expandable expanded={this.state.expanded} onHeaderClick={this.toggleExpanded}>
             <Fragment>
               <p className={'toggles float-right'}>

--- a/client/schema/v1/index.js
+++ b/client/schema/v1/index.js
@@ -1871,6 +1871,12 @@ each other.`,
                 hint: 'Explain where one or more steps are repeated in one experiment, list any alternative techniques within a step (e.g. dosing routes), and include all procedures performed under terminal anaesthesia.\n\nWhen describing the technical aspects of a step, be broad enough to be flexible when the variation does not impact on animal welfare (e.g. use "antibiotic" instead of "penicillin"). Finally, avoid specifying volumes and frequencies when they do not impact on animal welfare.'
               },
               {
+                name: 'reference',
+                type: 'text',
+                label: 'Step reference',
+                hint: 'Provide a short reference for this step, e.g. \'Blood sampling\' or \'Transgene induction\''
+              },
+              {
                 name: 'optional',
                 label: 'Is this step optional?',
                 type: 'radio',
@@ -1918,6 +1924,23 @@ each other.`,
                         type: 'texteditor'
                       }
                     ]
+                  },
+                  {
+                    label: 'No',
+                    value: false
+                  }
+                ]
+              },
+              {
+                name: 'reusable',
+                label: 'Do you want to be able to use this step on other protocols?',
+                type: 'radio',
+                inline: true,
+                className: 'smaller',
+                options: [
+                  {
+                    label: 'Yes',
+                    value: true
                   },
                   {
                     label: 'No',


### PR DESCRIPTION
This will now store reusable steps in a property at the top level of the project-versions:
```
"reusableSteps": {
  "39b40f1d-0cb3-47b2-8ebe-0306ec2a5ba0": {
    "id": "39b40f1d-0cb3-47b2-8ebe-0306ec2a5ba0",
    "saved": true,
    "title": {
    ...
    },
    "adverse": true,
    "optional": false,
    "reusable": true,
    "completed": true,
  }
}
```

Where a step within the protocols is using a re-usable step, it will only include the id, and a reusableStepId:
```
"steps": [
  {
  "id": "39b40f1d-0cb3-47b2-8ebe-0306ec2a5ba0",
  "reusableStepId": "39b40f1d-0cb3-47b2-8ebe-0306ec2a5ba0"
  }
]

```
**Editing step:**
Now shows new step reference and re-use question

![Steps editing - Edit](https://user-images.githubusercontent.com/1784700/193542981-7c29b019-9c56-43a6-bcbd-04ee3528ac19.png)

___

**Adding a new step**
When there is at least one re-usable step, then when adding a step the following option is available:

![Add new step selector](https://user-images.githubusercontent.com/1784700/193543855-f2b85304-0e45-4b59-ac4b-baeeef5e6289.png)

___

**View Step:** 
This now has an option to:
Edit the step, which creates a new step with details completed and the original details in existingValues field so the chance can be cancelled.
Edit every instance, which creates a copy of the values in existingValues for cancelling.

![Steps editing - View](https://user-images.githubusercontent.com/1784700/193543114-af0ffb38-bd0a-4a9a-b8b4-4bb534d6bc12.png)

___

**Review screen**
Changed to use expandable components, with the reference, or first line of text if no reference provided

![Review Expandable](https://user-images.githubusercontent.com/1784700/193543560-f9723be5-1eb9-41f5-9676-91253e89755e.png)

___

**Granted Licence**

Now displays the reference in the index and step header if it is present.
![Granted Licence](https://user-images.githubusercontent.com/1784700/193543961-154f780f-2ff1-45b2-9fcd-756cf1247073.png)
