### PR TITLE
Set rows on condition textareas to fit default text

### DIFF
--- a/client/components/editable.js
+++ b/client/components/editable.js
@@ -66,6 +66,8 @@ function Editable({ edited,
         value={state.content}
         onChange={onContentChange}
         autoExpand={true}
+        // set the rows to fit the default text, 72 has no inherent value it just works as a good average character length
+        rows={Math.ceil((state.content.length) / 72)}
       />
 
       {


### PR DESCRIPTION
https://collaboration.homeoffice.gov.uk/jira/browse/ASL-4107

Textareas now fit the default text when you begin editing
