### PR TITLE
Add autofocus to condition text areas so they are automatically the correct size

### DIFF
--- a/client/components/editable.js
+++ b/client/components/editable.js
@@ -66,6 +66,8 @@ function Editable({ edited,
         value={state.content}
         onChange={onContentChange}
         autoExpand={true}
+        // do not add autofocus to the custom condition as it is loaded before you enable it
+        autoFocus={state.content !== ''}
       />
 
       {


### PR DESCRIPTION
Add autoFocus to Editable component
Custom conditions contain no content and are loaded before they are enabled by the user so added a conditional to not enable auto focus