### PR TITLE
ASL-4046 - Fallback to truncated title then 'Unnamed step' if no reference on reusable step

### DIFF
--- a/client/helpers/steps.js
+++ b/client/helpers/steps.js
@@ -37,8 +37,13 @@ export const hydrateSteps = (protocols, steps, reusableSteps) => {
   return [hydratedSteps, Object.values(reusableSteps)];
 };
 
-export const getStepTitle = title => {
-  const untitled = <em>Untitled step</em>;
+export const getTruncatedStepTitle = (step, numCharacters) => {
+  const title = getStepTitle(step.title, null);
+  if (!title || title.trim() === '') return null;
+  return title.substring(0, Math.min(title.length, numCharacters));
+};
+
+export const getStepTitle = (title, untitled = <em>Untitled step</em>) => {
   if (!title) {
     return untitled;
   }

--- a/client/pages/sections/protocols/steps.js
+++ b/client/pages/sections/protocols/steps.js
@@ -14,7 +14,7 @@ import NewComments from '../../../components/new-comments';
 import ChangedBadge from '../../../components/changed-badge';
 import {v4 as uuid} from 'uuid';
 import Review from '../../../components/review';
-import {getStepTitle, hydrateSteps} from '../../../helpers/steps';
+import {getStepTitle, getTruncatedStepTitle, hydrateSteps} from '../../../helpers/steps';
 import {saveReusableSteps} from '../../../actions/projects';
 import Expandable from '../../../components/expandable';
 import cloneDeep from 'lodash/cloneDeep';
@@ -325,19 +325,28 @@ class Step extends Component {
 }
 
 const StepSelector = ({ reusableSteps, values, onSaveSelection, length, onCancel }) => {
+  const DEFAULT_STEP_REFERENCE = 'Unnamed step';
+  const MAX_CHARACTERS_FROM_TITLE = 80;
   const [selectedSteps, setSelectedSteps] = useState([]);
+  const references = {};
+  const options = uniqBy(reusableSteps, 'id')
+    .map(reusableStep => {
+      const reference = reusableStep.reference || getTruncatedStepTitle(reusableStep, MAX_CHARACTERS_FROM_TITLE) || DEFAULT_STEP_REFERENCE;
+      const referenceCount = references[reference] || 0;
+      references[reference] = referenceCount + 1;
+      return {
+        label: reference + (referenceCount > 0 ? ' ' + referenceCount : ''),
+        value: reusableStep.id
+      };
+    })
+    .sort((a, b) => (a.label.toLowerCase() > b.label.toLowerCase()) ? 1 : -1);
+
   const selectStepFields = [{
     name: 'select-steps',
     label: 'Select step',
     type: 'checkbox',
     className: 'smaller',
-    options: uniqBy(reusableSteps, 'id')
-      .map(reusableStep => {
-        return {
-          label: reusableStep.reference,
-          value: reusableStep.id
-        };
-      })
+    options: options
   }];
   const saveSelectionHandler = (e) => {
     onSaveSelection(selectedSteps);


### PR DESCRIPTION
This handles the case where there is no reference on a reusable step, first falling back to the first 80 characters of the description, then to Unnamed step.

If duplicates exist, it will start appending a number after the reference, description, default.

Adds ordering so the step references are in alphabetical order.

![Screenshot 2022-10-14 at 15 53 46](https://user-images.githubusercontent.com/1784700/195878034-0a0b8bd3-3f13-4e56-bdd7-e743432647a0.png)
