### PR TITLE
Explicitly set classnames to empty when passing props through to `<Review>` component

### DIFF
--- a/client/components/additional-availability.js
+++ b/client/components/additional-availability.js
@@ -9,6 +9,7 @@ function ReadOnly(props) {
     <Fragment>
       <Review
         {...props}
+        className=""
         value={props.values.name || props.values['establishment-name']}
         readonly={true}
       />
@@ -76,6 +77,7 @@ export default function AdditionalAvailability(props) {
         availableEstablishments.length === 0 && (
           <Review
             {...props}
+            className=""
             nullValue="No establishments available"
             value={null}
             readonly={true}

--- a/client/components/playback.js
+++ b/client/components/playback.js
@@ -32,6 +32,7 @@ const Playback = ({ project, step, history, field, section, readonly, basename, 
     <div className="playback">
       <Review
         { ...field }
+        className=""
         label={field.playbackLabel || field.label}
         hint={hint}
         value={project[field.name]}

--- a/client/components/review-fields.js
+++ b/client/components/review-fields.js
@@ -50,6 +50,7 @@ const ReviewFields = ({
             flattenReveals(fields.filter(field => fieldIncluded(field, project, application)), item).map(field => {
               return <Review
                 { ...field }
+                className=""
                 prefix={ prefix }
                 label={ field.review || field.label }
                 key={ field.name }

--- a/client/pages/sections/granted/project-summary.js
+++ b/client/pages/sections/granted/project-summary.js
@@ -27,6 +27,7 @@ const PermissiblePurpose = ({ values }) => {
     </div>
     : <Review
       {...permissiblePurpose}
+      className=""
       value={values['permissible-purpose']}
       noComments
     />;
@@ -101,6 +102,7 @@ export default function ProjectSummary({ fields = [], pdf }) {
             <div className="granted-section">
               <Review
                 {...fields.find(f => f.name === 'duration')}
+                className=""
                 value={values.duration}
                 noComments
               />

--- a/client/pages/sections/granted/protocol-steps.js
+++ b/client/pages/sections/granted/protocol-steps.js
@@ -10,6 +10,7 @@ const Step = ({ id, index, fields, prefix, ...props }) => {
         <h2 className="step-number">Step {index + 1} {props.reference && (<Fragment>: { props.reference }</Fragment>)} <span className="smaller">({ props.optional ? 'Optional' : 'Mandatory'})</span></h2>
         <Review
           {...fields.find(f => f.name === 'title')}
+          className=""
           label=""
           prefix={prefix}
           value={props.title}

--- a/client/pages/sections/legacy-introduction-review.js
+++ b/client/pages/sections/legacy-introduction-review.js
@@ -46,6 +46,7 @@ const LegacyIntroduction = ({ fields, project, values, pdf, readonly, title, lic
         values.continuation && (
           <Review
             {...continuationField}
+            className=""
             label={continuationField.grantedLabel}
             value={values.continuation}
             values={values}

--- a/client/pages/sections/objectives/review.js
+++ b/client/pages/sections/objectives/review.js
@@ -34,6 +34,7 @@ const ObjectivesReview = ({ playback, values, steps, goto, readonly, isFullAppli
           <Review
             key={index}
             {...steps[0].fields.find(f => f.name === 'title')}
+            className=""
             value={objective.title}
             prefix={`objectives.${objective.id}.`}
             onEdit={() => goto(0)}

--- a/client/pages/sections/protocols/steps.js
+++ b/client/pages/sections/protocols/steps.js
@@ -182,7 +182,7 @@ class Step extends Component {
               {...fields.find(f => f.name === 'reusable')}
               value={values.existingValues.reusable}
               readonly={true}
-              className={'reusable'}
+              className="reusable"
             />
             <Warning>You cannot change this answer when editing all instances of this step.</Warning>
           </Fragment>

--- a/client/pages/sections/repeater/review.js
+++ b/client/pages/sections/repeater/review.js
@@ -22,6 +22,7 @@ export function ReviewRepeater({ items = [], singular, fields, name, step, hideC
                     <Review
                       key={field.name}
                       {...field}
+                      className=""
                       value={item[field.name]}
                       prefix={prefix}
                       editLink={editLink}


### PR DESCRIPTION
The component previously ignored `className` prop, but now applies it, so in cases where it might accidentally be passed through by passing all field properties to the component explicitly set it to `""`.