### PR TITLE
ASL-4046 - Include reference + repeated from for re-usable/re-used step headers on 'View latest submission' playback

### DIFF
--- a/client/pages/sections/protocols/steps.js
+++ b/client/pages/sections/protocols/steps.js
@@ -139,7 +139,8 @@ class Step extends Component {
       protocol,
       newComments,
       reusableSteps,
-      pdf
+      pdf,
+      readonly
     } = this.props;
     const changeFieldPrefix = values.reusableStepId ? `reusableSteps.${values.reusableStepId}.` : this.props.prefix;
 
@@ -242,14 +243,17 @@ class Step extends Component {
           }
           <h3>
             {`Step ${index + 1}`}
-            {pdf && values.reference && (<Fragment>: { values.reference }</Fragment>)}
+            {(pdf || readonly) && values.reference && (<Fragment>: { values.reference }</Fragment>)}
             {
               completed && !isUndefined(values.optional) &&
               <span className="light smaller">{` (${values.optional === true ? 'optional' : 'mandatory'})`}</span>
             }
+            {
+              !pdf && readonly && repeatedFrom && <div className="light smaller">{`Repeated from protocol ${repeatedFrom}`}</div>
+            }
           </h3>
           {
-            pdf && repeatedFrom && <span className="review"><p className="grey">{`Repeated from protocol ${repeatedFrom}`}</p></span>
+            pdf && !readonly && repeatedFrom && <span className="review"><p className="grey">{`Repeated from protocol ${repeatedFrom}`}</p></span>
           }
         </Fragment>
         <EditStepWarning editingReusableStep={editingReusableStep} protocol={protocol} step={values} completed={completed}/>

--- a/client/pages/sections/protocols/steps.js
+++ b/client/pages/sections/protocols/steps.js
@@ -253,7 +253,7 @@ class Step extends Component {
             }
           </h3>
           {
-            pdf && !readonly && repeatedFrom && <span className="review"><p className="grey">{`Repeated from protocol ${repeatedFrom}`}</p></span>
+            pdf && repeatedFrom && <span className="review"><p className="grey">{`Repeated from protocol ${repeatedFrom}`}</p></span>
           }
         </Fragment>
         <EditStepWarning editingReusableStep={editingReusableStep} protocol={protocol} step={values} completed={completed}/>


### PR DESCRIPTION
I missed the View latest submission playback when adding the reference and 'repeated from protocol X' to the step headers.

![Screenshot 2022-10-19 at 08 27 59](https://user-images.githubusercontent.com/1784700/196625474-d95098cd-8e04-4ff0-822d-043042621b99.png)
