### PR TITLE
Disable hidden checkbox to stop translation research being displayed twice

### DIFF
--- a/assets/scss/projects.scss
+++ b/assets/scss/projects.scss
@@ -2,6 +2,7 @@
 @import "images";
 $light-green: #26A197;
 $pink: #ff1493;
+$hint-colour: #696F73;
 
 @mixin sticky {
   position: -webkit-sticky;
@@ -1622,6 +1623,7 @@ html.modal-open, html.modal-open body {
   // and to remove the checkbox for the reveal option
   input[name="permissible-purpose"][value="translational-research"] {
     & + label {
+      opacity: 1 !important;
       &:before,
       &:after {
         display: none;

--- a/client/schema/v1/permissible-purpose.js
+++ b/client/schema/v1/permissible-purpose.js
@@ -11,6 +11,7 @@ const permissiblePurpose = {
     {
       label: '(b) Translational or applied research with one of the following aims:',
       value: 'translational-research',
+      disabled: true,
       reveal: {
         name: 'translational-research',
         label: '',


### PR DESCRIPTION
The bug https://collaboration.homeoffice.gov.uk/jira/browse/ASL-4119 is caused by users clicking a hidden checkbox which then causes flattenReveals to run on the translational research values, giving it it's own section when being reviewed.

Disabling the hidden checkbox stops it from being added to values and will stop this bug happening in the future.
Added styling to stop the disabled checkbox losing opacity
