### PR TITLE
Stop flattening translational research options when the invisible checkbox is ticked

### DIFF
--- a/client/helpers/index.js
+++ b/client/helpers/index.js
@@ -124,6 +124,10 @@ export const flattenReveals = (fields, values) => {
     if (item.options && !item.preserveHierarchy) {
       item.options.forEach(option => {
         if (option.reveal) {
+          // fixes ASL-4119 where the user has already clicked the hidden checkbox
+          if (option.value === 'translational-research') {
+            return null;
+          }
           if (Array.isArray(values[item.name]) && values[item.name].includes(option.value)) {
             reveals.push(flattenReveals(castArray(option.reveal), values));
           } else if (option.value === values[item.name]) {


### PR DESCRIPTION
This is a fix for users who have already encountered the bug. Checks if translational research is being assessed in the flattener and skips over it.