### PR TITLE
Remove duplicated subtitle on PPL review

### DIFF
--- a/client/schema/v1/index.js
+++ b/client/schema/v1/index.js
@@ -2948,7 +2948,6 @@ each other.`,
   },
   conditions: {
     title: 'Additional conditions and authorisations',
-    subtitle: 'Additional conditions',
     show: props => props.showConditions,
     subsections: {
       conditions: {


### PR DESCRIPTION
https://collaboration.homeoffice.gov.uk/jira/browse/ASL-3263

Removes 'Additional conditions' subtitle as it was duplicated.

<img width="727" alt="Screenshot 2022-10-28 at 14 08 43" src="https://user-images.githubusercontent.com/61828376/198599650-f3714e73-4cbc-4b3c-bcad-0c2c779e9635.png">

<img width="412" alt="Screenshot 2022-10-28 at 14 08 56" src="https://user-images.githubusercontent.com/61828376/198599736-071da874-9345-4c5a-9369-08e9093e50a5.png">
