### PR TITLE
ASL-4127 - Default steps to collapsed on 'View latest submission' & add open/close all steps

### DIFF
--- a/client/helpers/steps.js
+++ b/client/helpers/steps.js
@@ -1,18 +1,17 @@
 import {Value} from 'slate';
 import React from 'react';
-import { uniq } from 'lodash';
+import {uniq, flatMap} from 'lodash';
 
 export const hydrateSteps = (protocols, steps, reusableSteps) => {
 
   const reusableStepsInAllProtocols =
-    (protocols || [])
-      .filter(protocol => !protocol.deleted)
-      .flatMap((protocol, index) => (protocol.steps || [])
-        .filter(step => !!step.reusableStepId)
-        .map(step => {
-          return { reusableStepId: step.reusableStepId, protocolIndex: index + 1, protocolId: protocol.id };
-        })
-      )
+    flatMap((protocols || [])
+      .filter(protocol => !protocol.deleted), (protocol, index) => (protocol.steps || [])
+      .filter(step => !!step.reusableStepId)
+      .map(step => {
+        return { reusableStepId: step.reusableStepId, protocolIndex: index + 1, protocolId: protocol.id };
+      })
+    )
       .reduce((map, reusableStep) => {
         if (!map[reusableStep.reusableStepId]) {
           map[reusableStep.reusableStepId] = [];


### PR DESCRIPTION
When displaying the steps within the 'View latest submission' screen, the steps will now be collapsed by default. And there is an option to Open all steps (which I missed in the original reusable steps designs)
![Screenshot 2022-11-02 at 13 50 54](https://user-images.githubusercontent.com/1784700/199507023-a81f5bf7-994c-4940-a1a5-4e048285b91b.png)


Have also updated the use of flatMap to use lodash