### PR TITLE
Bugfix/scrollable tables

### DIFF
--- a/assets/scss/projects.scss
+++ b/assets/scss/projects.scss
@@ -1669,3 +1669,33 @@ html.modal-open, html.modal-open body {
   padding: 0 0.5em;
   color: $hint-colour;
 }
+
+.rte-table-container {
+  overflow: auto;
+
+  @media (min-width: 641px) {
+    max-width: 1054px;
+  }
+
+  @media (min-width: 1260px) {
+    max-width: 1186px;
+  }
+
+  @media (max-width: 640px) {
+    max-width: 926px;
+  }
+}
+
+.rte-table-cell {
+  @media (min-width: 641px) {
+    min-width: 175px;
+  }
+
+  @media (min-width: 1200px) {
+    min-width: 200px;
+  }
+
+  @media (max-width: 640px) {
+    min-width: 155px;
+  }
+}

--- a/client/components/editor/table/renderers.js
+++ b/client/components/editor/table/renderers.js
@@ -17,9 +17,11 @@ const renderBlock = (props, editor, next) => {
         );
       }
       return (
-        <table {...attributes}>
-          <tbody>{children}</tbody>
-        </table>
+        <div className="rte-table-container">
+          <table {...attributes}>
+            <tbody>{children}</tbody>
+          </table>
+        </div>
       );
     case 'table-row':
       return <tr { ...attributes }>{ children }</tr>;
@@ -29,6 +31,7 @@ const renderBlock = (props, editor, next) => {
           colSpan={node.get('data').get('colSpan')}
           rowSpan={node.get('data').get('rowSpan')}
           {...attributes}
+          className="rte-table-cell"
         >
           {children}
         </td>


### PR DESCRIPTION
Add scrollable element to tables in rich text editors
Set cell widths to make the tables look better
Add CSS to new div to ensure sizing of the editor is unchanged

The table works on its own axis and scrolling doesn't effect the information around it.

Before
<img width="959" alt="Screenshot 2022-11-07 at 12 18 26" src="https://user-images.githubusercontent.com/61828376/200308561-d19b2b9b-399a-4b60-b5c3-46219f706892.png">

After
<img width="905" alt="Screenshot 2022-11-07 at 12 21 45" src="https://user-images.githubusercontent.com/61828376/200309155-757f68e0-3ddf-46fc-9592-c613b1e93135.png">

This also adds a scroller to the review page.
<img width="564" alt="Screenshot 2022-11-07 at 13 48 01" src="https://user-images.githubusercontent.com/61828376/200326097-f6cd01c0-6137-4f04-96f3-10c07b52cf09.png">

