### PR TITLE
ASL-4171 - Show details for re-useable step on protocols summary

### DIFF
--- a/client/pages/sections/granted/summary-table.js
+++ b/client/pages/sections/granted/summary-table.js
@@ -7,7 +7,7 @@ function titleCase(str) {
   return `${str.charAt(0).toUpperCase()}${str.substring(1)}`;
 }
 
-function TableRow({ species, protocol, index, isLegacy, ExpandingRow, expanded, onClick }) {
+function TableRow({ species, project, protocol, index, isLegacy, ExpandingRow, expanded, onClick }) {
   // this is necessary due to :hover css not taking rowspan into account.
   const [hover, setHover] = useState(false);
   function onMouseEnter() {
@@ -80,7 +80,7 @@ function TableRow({ species, protocol, index, isLegacy, ExpandingRow, expanded, 
           showExpandingRow && speciesIndex === species.length - 1 && (
             <tr className={classnames({ hidden: !expanded })}>
               <td colSpan="8" className="expanding-container">
-                <ExpandingRow protocol={protocol} />
+                <ExpandingRow protocol={protocol} project={project} />
               </td>
             </tr>
           )
@@ -161,6 +161,7 @@ export default function SummaryTable({ protocols, isLegacy, project, className, 
               return <TableRow
                 key={index}
                 species={species}
+                project={project}
                 protocol={protocol}
                 index={index}
                 isLegacy={isLegacy}

--- a/client/pages/sections/protocols/summary-table.js
+++ b/client/pages/sections/protocols/summary-table.js
@@ -4,8 +4,10 @@ import { Button } from '@ukhomeoffice/react-components';
 import Table from '../granted/summary-table';
 import ReviewField from '../../../components/review-field';
 import ProtocolConditions from './protocol-conditions';
+import {hydrateSteps} from '../../../helpers/steps';
 
-function ExpandingRow({ protocol }) {
+function ExpandingRow({ protocol, project }) {
+  const [ steps ] = hydrateSteps(project.protocols, protocol.steps || [], project.reusableSteps || {});
   return (
     <Fragment>
       <h3>Where this protocol can be carried out</h3>
@@ -14,7 +16,7 @@ function ExpandingRow({ protocol }) {
         value={protocol.locations}
       />
       {
-        (protocol.steps || []).map((s, index) => (
+        steps.map((s, index) => (
           <Fragment key={index}>
             <h3>{`Step ${index + 1} (${s.optional ? 'optional' : 'mandatory'})`}</h3>
             <ReviewField


### PR DESCRIPTION
This should fix the issue where details of a re-usable step are not appearing on the `View summary table (opens in a new tab)` page. It needed to hydrate the steps to pull the information from the reusableSteps where applicable