### PR TITLE
Tweak error reporting on intermittent project sync failure & when login session no longer valid

### DIFF
--- a/client/actions/messaging.js
+++ b/client/actions/messaging.js
@@ -39,7 +39,7 @@ export default function sendMessage({ method, data, url }) {
       // detect if redirect was attempted
       if (response.type === 'opaqueredirect') {
         window.onbeforeunload = null;
-        return window.location.reload();
+        window.location.reload();
       }
       return response.json()
         .then(json => {

--- a/client/actions/projects.js
+++ b/client/actions/projects.js
@@ -257,11 +257,11 @@ const onSyncError = (func, error, dispatch, getState, ...args) => {
   if (error.code === 'UPDATE_REQUIRED') {
     return dispatch(throwError('This software has been updated. You must refresh your browser to avoid losing work.'));
   }
+  console.error(error);
   if (errorCount > 5) {
+    postError({ error });
     return dispatch(throwError('Failed to save your changes. Try refreshing your browser to continue. If the problem persists then please report to aspeltechnicalqueries@homeoffice.gov.uk'));
   }
-  console.error(error);
-  postError({ error });
   dispatch(throwError(`Failed to save, trying again in ${Math.pow(2, errorCount)} seconds`));
   return setTimeout(() => func(dispatch, getState, ...args), 1000 * Math.pow(2, errorCount));
 };


### PR DESCRIPTION
I have managed to re-create a couple of the errors we are seeing regular alerts for:

**Problem 1:**
If a user is editing a project application (protocols for example) and the user is logged out in another tab (I think the same would happen if the session expired) then when a change is made to the page it will redirect to the login page, but will also try and determine the changes from the response from the server because `window.location.reload()` is being returned. This results in `Cannot read properties of undefined (reading 'changes')`
**Solution**
Have removed the return, so the page will just redirect, and no more of the save logic will be attempted.

**Problem 2** 
When there is a network issue when syncing the project (can recreate by throttling to Offline in Network tab in Chrome), then the error is sent to the server. The save would be attempted 5 times before it reports to the user that it cannot save, and there is a genuine problem.
**Solution**
Moved the error sending into the final attempt, so we are only ever alerted when there are more than 5 failed attempts to save.