### PR TITLE
ASSB-1285-1286: Fix comment count on reusable steps

### DIFF
--- a/client/helpers/steps.js
+++ b/client/helpers/steps.js
@@ -67,7 +67,7 @@ export const reusableStepFieldKeys = (protocol) => {
   }
   return (protocol.steps || [])
     .filter(step => step.reusableStepId)
-    .map(reusableStep => `reusableSteps.${reusableStep.reusableStepId}`);
+    .map(reusableStep => `protocols.${protocol.id}.reusableSteps.${reusableStep.reusableStepId}`);
 };
 
 export const getRepeatedFromProtocolIndex = (step, currentProtocolId) => {

--- a/client/pages/sections/protocols/sections.js
+++ b/client/pages/sections/protocols/sections.js
@@ -97,7 +97,8 @@ const getBadges = (section, newComments, values) => {
   let relevantComments;
   if (section.repeats) {
     const re = new RegExp(`^${section.repeats}\\.`);
-    relevantComments = pickBy(newComments, (value, key) => key.match(re));
+    relevantComments = section.title !== 'Steps' ? pickBy(newComments, (value, key) => key.match(re))
+      : pickBy(newComments, (value, key) => key.match(re) || key.match('^reusableSteps\\.'));
   } else {
     relevantComments = pick(newComments, flattenReveals(section.fields, values).map(field => field.name));
   }

--- a/client/pages/sections/protocols/steps.js
+++ b/client/pages/sections/protocols/steps.js
@@ -136,9 +136,9 @@ class Step extends Component {
       expanded,
       onToggleExpanded
     } = this.props;
-    const changeFieldPrefix = values.reusableStepId ? `reusableSteps.${values.reusableStepId}.` : this.props.prefix;
+    const changeFieldPrefix = values.reusableStepId ? `protocols.${protocol.id}.reusableSteps.${values.reusableStepId}.` : this.props.prefix;
 
-    const re = new RegExp(`^steps.${values.id}\\.`);
+    const re = new RegExp(`^(reusable)?S?s?teps.${values.id}\\.`);
     const relevantComments = Object.values(
       pickBy(newComments, (value, key) => key.match(re))
     ).reduce((total, comments) => total + (comments || []).length, 0);

--- a/package-lock.json
+++ b/package-lock.json
@@ -8312,6 +8312,7 @@
     },
     "node_modules/unix-dgram": {
       "version": "2.0.4",
+      "hasInstallScript": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {


### PR DESCRIPTION
The way reusable steps was set up meant that the comment counter didn't flag new comments made as they were not appended with protocols.protocolId.

Also didn't flag on the protocol or step levels as the regexs looked for steps.stepId rather than reusableStep.stepId