### PR TITLE
Fixes issue with reusable step titles after they are edited

### DIFF
--- a/client/pages/sections/protocols/steps.js
+++ b/client/pages/sections/protocols/steps.js
@@ -75,8 +75,10 @@ class Step extends Component {
   }
 
   editThisStep = e => {
+    const editFlagApplied = this.props.values.reference && this.props.values.reference.slice(-8) === '(edited)';
+    const newReference = editFlagApplied ? this.props.values.reference : `${this.props.values.reference} (edited)`;
     e.preventDefault();
-    this.props.updateItem({ completed: false, reference: `${this.props.values.reference} (edited)`, reusableStepId: uuid(), saved: false, existingValues: cloneDeep(this.props.values) });
+    this.props.updateItem({ completed: false, reference: this.props.values.reference ? newReference : null, reusableStepId: uuid(), saved: false, existingValues: cloneDeep(this.props.values) });
     this.scrollToStep();
   }
 


### PR DESCRIPTION
Fixes an issue where the step reference would be set to 'Undefined (edited)' if a step was:
1) reusable
2) did not have a reference
3) the user clicked 'edit just this step'

Also fixes an issue where '(edited)' would be appended to the step reference every time it was edited, now only adds it if it doesn't already have it appended.
https://collaboration.homeoffice.gov.uk/jira/browse/ASSB-1287