### PR TITLE
ASSB-1292: Fix user unable to edit and resubmit PPL transfer

### DIFF
--- a/client/components/editor/index.js
+++ b/client/components/editor/index.js
@@ -54,6 +54,9 @@ const serialiseValue = value => {
 };
 
 const normaliseValue = value => {
+  // bugfix ASSB-1292 - for PPL transfers between holders: when the user removes a value from the form the value is set to the string null rather than the value null
+  // this is a temporary fix so the user is unblocked whilst I look for the cause
+  if (value === 'null') value = null;
   // if value is falsy, init with empty value
   if (!value) {
     return initialValue('');


### PR DESCRIPTION
At the moment when the user removes a value from the form the value is set to 'null' rather than null. This causes the rich text editor to break as it tries to use this to fill the editor, rather than the nodes it gets from initialValue('')
https://collaboration.homeoffice.gov.uk/jira/browse/ASSB-1292