### PR TITLE
ASSB-1295: Fixes bug where steps.forEach does not work

### DIFF
--- a/client/pages/sections/protocols/protocols.js
+++ b/client/pages/sections/protocols/protocols.js
@@ -74,10 +74,11 @@ class Protocol extends PureComponent {
 
     // for each protocol: map through new comments, if the protocol includes a reusable step that has a comment (key includes id)
     // insert the protocol id to the comment to flag it as a new comment on the protocol
+    const steps = this.props.values.steps ? this.props.values.steps : null;
     let match = false;
-    const updatedComments = Object.fromEntries(
+    const updatedComments = steps ? Object.fromEntries(
       Object.entries(this.props.newComments).map(([key, value]) => {
-        this.props.values.steps.forEach(step => {
+        steps.forEach(step => {
           if (key.includes(step.reusableStepId)) {
             match = true;
           }
@@ -85,7 +86,7 @@ class Protocol extends PureComponent {
         const newKey = match ? key.replace('protocols.reusableSteps.', `protocols.${this.props.values.id}.reusableSteps.`) : key;
         return [newKey, value];
       })
-    );
+    ) : this.props.newComments;
 
     const newComments = mapKeys(
       pickBy(updatedComments, (comments, key) => {


### PR DESCRIPTION
Added this to fix a bug with the count of comments not being correct 2 weeks ago.
Now there is a bug where e.props.values.steps.forEach is not a function
Fixes it by only running updatedComments when the steps exist to be mapped, if it does not exist it uses the default set of newComments which have not been updated with the protocol numbers.

<img width="1009" alt="Screenshot 2023-05-03 at 15 30 53" src="https://user-images.githubusercontent.com/61828376/235947158-d69b7583-2080-4f3a-a139-cb2511bf9e87.png">
