### PR TITLE
remove hardcoded lenny

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -4,5 +4,3 @@
 
 //artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/:username=${NPM_AUTH_USERNAME}
 //artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/:_password=${NPM_AUTH_TOKEN}
-//artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/:email=leonard.martin@digital.homeoffice.gov.uk
-//artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/:always-auth=true

--- a/.npmrc
+++ b/.npmrc
@@ -1,6 +1,8 @@
-@asl:registry = https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/
 @ukhomeoffice:registry=https://npm.pkg.github.com
 //npm.pkg.github.com/:_authToken=${GITHUB_AUTH_TOKEN}
 
+@asl:registry = https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-registry-remote/
 //artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/:username=${NPM_AUTH_USERNAME}
 //artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/:_password=${NPM_AUTH_TOKEN}
+//artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-registry-remote/:email=ralph.cowling1@digital.homeoffice.gov.uk
+//artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-registry-remote/:always-auth=true


### PR DESCRIPTION
We still have lenny's email in our .npmrc, and we're likely using his token. Let's change this by removing hardcoded refs to him and updating the npm credentials in drone