### PR TITLE
Fix "other-establishments" logic

### DIFF
--- a/client/helpers/get-locations.js
+++ b/client/helpers/get-locations.js
@@ -1,10 +1,13 @@
 const uniq = require('lodash/uniq');
 
-export default function getLocations (project, establishment) {
-  const establishments = (project.establishments || [])
-    .filter(e => e.name || e['establishment-name'])
-    .filter(e => !e.deleted) // AA which is being removed during amendment
-    .map(e => e.name || e['establishment-name']);
+export default function getLocations(project, establishment) {
+
+const establishments = project['other-establishments']
+  ? (project.establishments || [])
+      .filter(e => e.name || e['establishment-name'])
+      .filter(e => !e.deleted) // AA which is being removed during amendment
+      .map(e => e.name || e['establishment-name'])
+  : []
 
   const poles = (project.polesList || []).filter(p => p.title).map(p => p.title);
 

--- a/client/helpers/get-locations.js
+++ b/client/helpers/get-locations.js
@@ -2,12 +2,12 @@ const uniq = require('lodash/uniq');
 
 export default function getLocations(project, establishment) {
 
-const establishments = project['other-establishments']
-  ? (project.establishments || [])
+  const establishments = project['other-establishments']
+    ? (project.establishments || [])
       .filter(e => e.name || e['establishment-name'])
       .filter(e => !e.deleted) // AA which is being removed during amendment
       .map(e => e.name || e['establishment-name'])
-  : []
+    : [];
 
   const poles = (project.polesList || []).filter(p => p.title).map(p => p.title);
 

--- a/test/specs/helpers/clean-protocols.js
+++ b/test/specs/helpers/clean-protocols.js
@@ -24,7 +24,7 @@ describe('clean-protocols', () => {
       ]
     };
     const establishment = {
-      name: 'University of Cheese'
+      name: 'University of Croydon'
     };
     assert.deepEqual(cleanProtocols({ state, changed, establishment }), {
       title: 'Test project',
@@ -35,7 +35,6 @@ describe('clean-protocols', () => {
       protocols: [
         {
           locations: [
-            'University of Cheese',
             'University of Croydon'
           ],
           objectives: []


### PR DESCRIPTION
- Do not show additional establishments list if "other-establishments" is `false`
- stops us from showing deselected other establishments

Only showing primary establishment after additional establishments has been deselected:

<img width="843" alt="Screenshot 2023-06-16 at 15 38 19" src="https://github.com/UKHomeOffice/asl-projects/assets/120181/463d176e-e96a-45c8-99d3-4f596b9a0641">
