### PR TITLE
Align naming of reusable step fields when referenced in protocols

### DIFF
--- a/client/helpers/steps.js
+++ b/client/helpers/steps.js
@@ -67,7 +67,7 @@ export const reusableStepFieldKeys = (protocol) => {
   }
   return (protocol.steps || [])
     .filter(step => step.reusableStepId)
-    .map(reusableStep => `reusableSteps.${reusableStep.reusableStepId}`);
+    .map(reusableStep => `protocols.${protocol.id}.reusableSteps.${reusableStep.reusableStepId}`);
 };
 
 export const getRepeatedFromProtocolIndex = (step, currentProtocolId) => {

--- a/client/pages/sections/protocols/protocols.js
+++ b/client/pages/sections/protocols/protocols.js
@@ -72,22 +72,6 @@ class Protocol extends PureComponent {
   render() {
     const { editable } = this.props;
 
-    // for each protocol: map through new comments, if the protocol includes a reusable step that has a comment (key includes id)
-    // insert the protocol id to the comment to flag it as a new comment on the protocol
-    // const steps = this.props.values.steps ? this.props.values.steps : null;
-    // let match = false;
-    // const updatedComments = steps ? Object.fromEntries(
-    //   Object.entries(this.props.newComments).map(([key, value]) => {
-    //     steps.forEach(step => {
-    //       if (key.includes(step.reusableStepId)) {
-    //         match = true;
-    //       }
-    //     });
-    //     const newKey = match ? key.replace('protocols.reusableSteps.', `protocols.${this.props.values.id}.reusableSteps.`) : key;
-    //     return [newKey, value];
-    //   })
-    // ) : this.props.newComments;
-
     const newComments = mapKeys(
       pickBy(this.props.newComments, (comments, key) => {
         const re = new RegExp(`^protocols.${this.props.values.id}`);

--- a/client/pages/sections/protocols/steps.js
+++ b/client/pages/sections/protocols/steps.js
@@ -30,7 +30,7 @@ function renderUsedInProtocols(protocolIndexes) {
   return `${protocolIndexes.slice(0, protocolIndexes.length - 1).join(',')} and ${protocolIndexes[protocolIndexes.length - 1]}`;
 }
 
-const changeFields = (step, prefix) => step.reusable ? [ `reusableSteps.${step.reusableStepId}` ] : [ prefix.substr(0, prefix.length - 1) ];
+const changeFields = (prefix) => [ prefix.substr(0, prefix.length - 1) ];
 
 class Step extends Component {
   constructor(options) {
@@ -138,7 +138,7 @@ class Step extends Component {
       expanded,
       onToggleExpanded
     } = this.props;
-    const changeFieldPrefix = values.reusableStepId ? `reusableSteps.${values.reusableStepId}.` : this.props.prefix;
+    const changeFieldPrefix = values.reusableStepId ? `protocols.${protocol.id}.reusableSteps.${values.reusableStepId}.` : this.props.prefix;
 
     const re = values.reusableStepId ? new RegExp(`^(reusable)?S?s?teps.(${values.id})?(${values.reusableStepId})?\\.`) : new RegExp(`^(reusable)?S?s?teps.${values.id}\\.`);
     const relevantComments = Object.values(
@@ -221,7 +221,7 @@ class Step extends Component {
         ref={this.step}
       >
         <NewComments comments={relevantComments} />
-        <ChangedBadge fields={changeFields(values, changeFieldPrefix)} protocolId={protocol.id} />
+        <ChangedBadge fields={changeFields(changeFieldPrefix)} protocolId={protocol.id} />
         <Fragment>
           {
             editable && completed && !deleted && (
@@ -311,7 +311,7 @@ class Step extends Component {
       return (
         <section className={'review-step'}>
           <NewComments comments={relevantComments} />
-          <ChangedBadge fields={changeFields(values, changeFieldPrefix)} protocolId={protocol.id} />
+          <ChangedBadge fields={changeFields(changeFieldPrefix)} protocolId={protocol.id} />
           <Expandable expanded={expanded} onHeaderClick={() => onToggleExpanded(index)}>
             <Fragment>
               <p className={'toggles float-right'}>


### PR DESCRIPTION
Add 'protocols.<id>' prefix in a few locations where it was missed for "reusableSteps" fields
This should address some of the discrepancies observed when reusable step fields are commented