### PR TITLE
Bugfix/assb 1345 without diff window regression

### DIFF
--- a/client/components/review.js
+++ b/client/components/review.js
@@ -98,9 +98,15 @@ class Review extends React.Component {
 
 const mapStateToProps = ({ application: { readonly, isGranted, previousProtocols } = {}, changes: { first = [], latest = [], granted = [] } = {} }, ownProps) => {
   const key = `${ownProps.prefix || ''}${ownProps.name}`;
-  const changedFromGranted = granted.includes(key);
-  const changedFromLatest = latest.includes(key);
-  const changedFromFirst = first.includes(key);
+  // The adjustedKey (stripping out the 'protocols.' prefix from reusable step key) is
+  // to workaround the fact that reusable steps change fields don't have the 'protocols.' prefix.
+  // The Diff Window (aka 'See what's changed') would break otherwise
+  const reusableStepsPosition = key.indexOf('reusableSteps.');
+  const adjustedKey = (reusableStepsPosition < 0) ? key : key.substring(reusableStepsPosition);
+
+  const changedFromGranted = granted.includes(adjustedKey);
+  const changedFromLatest = latest.includes(adjustedKey);
+  const changedFromFirst = first.includes(adjustedKey);
   return {
     readonly: ownProps.readonly || readonly,
     changedFromFirst,

--- a/client/pages/sections/protocols/steps.js
+++ b/client/pages/sections/protocols/steps.js
@@ -30,8 +30,6 @@ function renderUsedInProtocols(protocolIndexes) {
   return `${protocolIndexes.slice(0, protocolIndexes.length - 1).join(',')} and ${protocolIndexes[protocolIndexes.length - 1]}`;
 }
 
-const changeFields = (step, prefix) => step.reusable ? [ `reusableSteps.${step.reusableStepId}` ] : [ prefix.substr(0, prefix.length - 1) ];
-
 class Step extends Component {
   constructor(options) {
     super(options);
@@ -138,7 +136,11 @@ class Step extends Component {
       expanded,
       onToggleExpanded
     } = this.props;
+    // Default field prefix. e.g. For Comments component to work, it requires the field to have 'protocols.<protocol_id>' prefix
+    const fieldPrefix = values.reusableStepId ? `protocols.${protocol.id}.reusableSteps.${values.reusableStepId}.` : this.props.prefix;
+    // Change field prefix. The list of changes don't include the protocols prefix, so it has to be removed here
     const changeFieldPrefix = values.reusableStepId ? `reusableSteps.${values.reusableStepId}.` : this.props.prefix;
+    const changeFields = [changeFieldPrefix.substr(0, changeFieldPrefix.length - 1)];
 
     const re = values.reusableStepId ? new RegExp(`^(reusable)?S?s?teps.(${values.id})?(${values.reusableStepId})?\\.`) : new RegExp(`^(reusable)?S?s?teps.${values.id}\\.`);
     const relevantComments = Object.values(
@@ -154,7 +156,7 @@ class Step extends Component {
         <ReviewFields
           fields={[fields.find(f => f.name === 'title')]}
           values={{ title: values.title }}
-          prefix={changeFieldPrefix}
+          prefix={fieldPrefix}
           editLink={`0#${this.props.prefix}`}
           protocolId={protocol.id}
           readonly={!isReviewStep}
@@ -166,13 +168,13 @@ class Step extends Component {
         ? <Fragment>
           {!editingReusableStep ? <Fieldset
             fields={fields}
-            prefix={changeFieldPrefix}
+            prefix={fieldPrefix}
             onFieldChange={(key, value) => updateItem({ [key]: value })}
             values={values}
           /> : <Fragment>
             <Fieldset
               fields={fields.filter(f => f.name !== 'reusable')}
-              prefix={changeFieldPrefix}
+              prefix={fieldPrefix}
               onFieldChange={(key, value) => updateItem({ [key]: value })}
               values={values}
             />
@@ -199,7 +201,7 @@ class Step extends Component {
           <ReviewFields
             fields={fields.filter(f => f.name !== 'title')}
             values={values}
-            prefix={changeFieldPrefix}
+            prefix={fieldPrefix}
             editLink={`0#${this.props.prefix}`}
             readonly={!isReviewStep}
             protocolId={protocol.id}
@@ -221,7 +223,7 @@ class Step extends Component {
         ref={this.step}
       >
         <NewComments comments={relevantComments} />
-        <ChangedBadge fields={changeFields(values, changeFieldPrefix)} protocolId={protocol.id} />
+        <ChangedBadge fields={changeFields} protocolId={protocol.id} />
         <Fragment>
           {
             editable && completed && !deleted && (
@@ -311,7 +313,7 @@ class Step extends Component {
       return (
         <section className={'review-step'}>
           <NewComments comments={relevantComments} />
-          <ChangedBadge fields={changeFields(values, changeFieldPrefix)} protocolId={protocol.id} />
+          <ChangedBadge fields={changeFields} protocolId={protocol.id} />
           <Expandable expanded={expanded} onHeaderClick={() => onToggleExpanded(index)}>
             <Fragment>
               <p className={'toggles float-right'}>

--- a/client/pages/sections/protocols/steps.js
+++ b/client/pages/sections/protocols/steps.js
@@ -140,7 +140,7 @@ class Step extends Component {
     const fieldPrefix = values.reusableStepId ? `protocols.${protocol.id}.reusableSteps.${values.reusableStepId}.` : this.props.prefix;
     // Change field prefix. The list of changes don't include the protocols prefix, so it has to be removed here
     const changeFieldPrefix = values.reusableStepId ? `reusableSteps.${values.reusableStepId}.` : this.props.prefix;
-    const changeFields = [changeFieldPrefix.substr(0, changeFieldPrefix.length - 1)];
+    const changeFields = [changeFieldPrefix.substring(0, changeFieldPrefix.length - 1)];
 
     const re = values.reusableStepId ? new RegExp(`^(reusable)?S?s?teps.(${values.id})?(${values.reusableStepId})?\\.`) : new RegExp(`^(reusable)?S?s?teps.${values.id}\\.`);
     const relevantComments = Object.values(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@asl/projects",
-  "version": "14.1.3",
+  "version": "14.1.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@asl/projects",
-      "version": "14.1.3",
+      "version": "14.1.4",
       "license": "MIT",
       "dependencies": {
         "@asl/service": "^10.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@asl/projects",
-  "version": "14.1.4",
+  "version": "14.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@asl/projects",
-      "version": "14.1.4",
+      "version": "14.1.3",
       "license": "MIT",
       "dependencies": {
         "@asl/service": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asl/projects",
-  "version": "14.1.3",
+  "version": "14.1.4",
   "description": "ASL PPL prototype",
   "main": "client/external.js",
   "styles": "assets/scss/projects.scss",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asl/projects",
-  "version": "14.1.4",
+  "version": "14.1.3",
   "description": "ASL PPL prototype",
   "main": "client/external.js",
   "styles": "assets/scss/projects.scss",


### PR DESCRIPTION
When the `.protocols` prefix was added to address reusable step comment count mismatch (see this PR: https://github.com/UKHomeOffice/asl-projects/pull/891), the URL of the API call used to fetch the data for the Diff Window, got broken (`version` parameter was set to `undefined`); further details can be found in this [JIRA ticket comment](https://collaboration.homeoffice.gov.uk/jira/browse/ASSB-1345?focusedCommentId=2781308&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel).

This was due to the key matched against the array of changed fields pertaining to reusable steps now having the `protocols.` prefix, whereas the changed fields from the array don't have it (all reusable steps fields start with `reusableSteps.`).

To address this, 2 different field prefix values are now used in the Protocols section: 
- One for the `ChangedBadge` component, without the `.protocols` prefix (`changeFieldPrefix`)
- And another default one, which has the `.protocols` prefix, for all other cases, including comment components (`fieldPrefix`)