### PR TITLE
bug: ASL-4532 - Fix initial submission first load issue

### DIFF
--- a/client/components/diff-window.js
+++ b/client/components/diff-window.js
@@ -48,7 +48,7 @@ const DiffWindow = (props) => {
   const before = useSelector(state => get(state.questionVersions, `['${props.name}'].${versions[active]}.value`));
 
   const changes = useSelector(state => {
-    if (props.type === 'keywords' && state.questionVersions['keywords']?.latest?.value?.length > 0 && before) {
+    if (props.type === 'keywords' && props.value.length > 0 && before) {
       return findArrayDifferences(before, props.value);
     }
     return get(state.questionVersions, `['${props.name}'].${versions[active]}.diff`, { added: [], removed: [] });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@asl/projects",
-  "version": "15.4.3",
+  "version": "15.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@asl/projects",
-      "version": "15.4.3",
+      "version": "15.4.4",
       "license": "MIT",
       "dependencies": {
         "@asl/service": "^10.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asl/projects",
-  "version": "15.4.3",
+  "version": "15.4.4",
   "description": "ASL PPL prototype",
   "main": "client/external.js",
   "styles": "assets/scss/projects.scss",


### PR DESCRIPTION
**Missed below scenario in previous testing:**
As soon as the page is loaded we don't see the coloring for in the proposed tab but it appears when switch tabs or refresh the browser, this is not the case with other elements like 'Rich text editor', 'Checkboxes' or 'radio group elements'
https://public-ui.dev.asl.homeoffice.gov.uk/establishments/8201/projects/805f025c-c74f-42b7-b58e-5b1594f49d12/versions/a168fe3e-dff5-4a5c-93e2-831a12a937a4/full-application/aims