### PR TITLE
[ASL-4495] Fix for window is undefined

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,5 @@
 extends:
-  - "./node_modules/@ukhomeoffice/asl-eslint-common/index.js"
+  - "@ukhomeoffice/asl"
 
 env:
   es6: true

--- a/client/helpers/index.js
+++ b/client/helpers/index.js
@@ -248,16 +248,9 @@ export const isTrainingLicence = values => {
 };
 
 export const getCurrentURLForFateOfAnimals = () => {
-  if (window.location.href) {
-    return window.location.href.split('/edit/')[0] + '/edit/fate-of-animals';
-  }
-  return null;
+  return typeof window !== 'undefined' ? window.location.href.split('/edit/')[0] + '/edit/fate-of-animals' : null;
 };
 
-export const UrlMarkdown = (linkText) => {
-  const url = getCurrentURLForFateOfAnimals();
-  if (url == null) {
-    return linkText;
-  }
-  return `[${linkText}](${url})`;
+export const markdownLink = (linkText, url) => {
+  return url ? `[${linkText}](${url})` : linkText;
 };

--- a/client/schema/v1/index.js
+++ b/client/schema/v1/index.js
@@ -34,7 +34,7 @@ import permissiblePurpose from './permissible-purpose';
 
 import confirmProtocolsAffected from '../../helpers/confirm-protocols-affected';
 
-import {isTrainingLicence, UrlMarkdown} from '../../helpers';
+import {isTrainingLicence, markdownLink, getCurrentURLForFateOfAnimals} from '../../helpers';
 
 export default () => {
   return ({
@@ -1969,7 +1969,7 @@ export default () => {
                 {
                   name: 'fate',
                   label: 'What will happen to animals at the end of this protocol?',
-                  hint: `Select all that apply. These options are based on what you selected in the ${UrlMarkdown('non-technical summary')}.`,
+                  hint: `Select all that apply. These options are based on what you selected in the ${markdownLink('non-technical summary', getCurrentURLForFateOfAnimals())}.`,
                   type: 'checkbox',
                   preserveHierarchy: true,
                   className: 'smaller',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@asl/projects",
-  "version": "15.4.5",
+  "version": "15.5.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@asl/projects",
-      "version": "15.4.5",
+      "version": "15.5.8",
       "license": "MIT",
       "dependencies": {
         "@asl/service": "^10.3.2",
@@ -52,7 +52,7 @@
       },
       "devDependencies": {
         "@babel/register": "^7.8.3",
-        "@ukhomeoffice/asl-eslint-common": "^2.2.0",
+        "@ukhomeoffice/eslint-config-asl": "^3.0.0",
         "babel-eslint": "^10.0.1",
         "eslint": "^7.32.0",
         "eslint-plugin-import": "^2.29.1",
@@ -2369,11 +2369,22 @@
       "resolved": "https://npm.pkg.github.com/download/@ukhomeoffice/asl-dictionary/2.1.0/681a630147a8a983861f66ff316540dbbf563ba0",
       "integrity": "sha512-bhi2L8RMu5AGjVTpYc05o6xYV5oHbdrTiTC4z0RCtpqJ/HWjufw+cD8+hvMG8579uYIaJwqC41E0pChrStU1nQ=="
     },
-    "node_modules/@ukhomeoffice/asl-eslint-common": {
-      "version": "2.2.0",
-      "resolved": "https://npm.pkg.github.com/download/@ukhomeoffice/asl-eslint-common/2.2.0/3a200fb4cce59f62ab84a437bea846c7c720b5fc",
-      "integrity": "sha512-C6UNb1FU49bgO+pRZQ6ETvITyyVz0R2TtCSOi3T8A3uhM/SKq2FJ2OOvrZ8eDTSVt8/EIkqbhYZMGgMSZ3rV2Q==",
+    "node_modules/@ukhomeoffice/asl-slate-edit-list": {
+      "version": "0.0.8",
+      "resolved": "https://npm.pkg.github.com/download/@ukhomeoffice/asl-slate-edit-list/0.0.8/63cb78074ecb40b82ec4e1a45421009a999ae0f7",
+      "integrity": "sha512-NaW/xYkwSC+u7/GVc5+ykPK9V6yLrJfL/EkyqubF5a2mJnQKofaN5LSAZelDuKBe7/pHM94doOnkJoB45q+Qkw==",
+      "peerDependencies": {
+        "immutable": "^3.8.2 || ^4.0.0-rc.12",
+        "slate": "^0.47.4",
+        "slate-react": "^0.22.4"
+      }
+    },
+    "node_modules/@ukhomeoffice/eslint-config-asl": {
+      "version": "3.0.0",
+      "resolved": "https://npm.pkg.github.com/download/@ukhomeoffice/eslint-config-asl/3.0.0/f4a5aff81ec8d8c9def91f17e71cd5197cb8f723",
+      "integrity": "sha512-Mmb/UfuA7AVW4D/T+2FjREdVTxhMbXtES4i83e7SiepTPmasLm4hTNiQNNk2xQexqKEBUYw/2zPgof2gATbR1g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "eslint-config-semistandard": "^11.0.0",
         "eslint-config-standard": "^10.2.1",
@@ -2385,16 +2396,6 @@
         "eslint-plugin-promise": "^3.5.0",
         "eslint-plugin-react": "^7.3.0",
         "eslint-plugin-standard": "^3.0.1"
-      }
-    },
-    "node_modules/@ukhomeoffice/asl-slate-edit-list": {
-      "version": "0.0.8",
-      "resolved": "https://npm.pkg.github.com/download/@ukhomeoffice/asl-slate-edit-list/0.0.8/63cb78074ecb40b82ec4e1a45421009a999ae0f7",
-      "integrity": "sha512-NaW/xYkwSC+u7/GVc5+ykPK9V6yLrJfL/EkyqubF5a2mJnQKofaN5LSAZelDuKBe7/pHM94doOnkJoB45q+Qkw==",
-      "peerDependencies": {
-        "immutable": "^3.8.2 || ^4.0.0-rc.12",
-        "slate": "^0.47.4",
-        "slate-react": "^0.22.4"
       }
     },
     "node_modules/@ukhomeoffice/frontend-toolkit": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asl/projects",
-  "version": "15.5.7",
+  "version": "15.5.8",
   "description": "ASL PPL prototype",
   "main": "client/external.js",
   "styles": "assets/scss/projects.scss",
@@ -67,7 +67,7 @@
   },
   "devDependencies": {
     "@babel/register": "^7.8.3",
-    "@ukhomeoffice/asl-eslint-common": "^2.2.0",
+    "@ukhomeoffice/eslint-config-asl": "^3.0.0",
     "babel-eslint": "^10.0.1",
     "eslint": "^7.32.0",
     "eslint-plugin-import": "^2.29.1",

--- a/test/specs/helpers/url-markdown.js
+++ b/test/specs/helpers/url-markdown.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import {getCurrentURLForFateOfAnimals, UrlMarkdown} from '../../../client/helpers';
+import {getCurrentURLForFateOfAnimals, markdownLink} from '../../../client/helpers';
 
 // Mock window object
 global.window = {
@@ -17,26 +17,32 @@ describe('getCurrentURLForFateOfAnimals', () => {
 
   it('should return null if window.location.href is not set', () => {
     // Mock the href to be null
-    window.location.href = '';
+    const prevWindow = window;
+    // eslint-disable-next-line no-global-assign
+    window = undefined;
+
     const result = getCurrentURLForFateOfAnimals();
     assert.strictEqual(result, null);
+
+    // eslint-disable-next-line no-global-assign
+    window = prevWindow;
   });
 });
 
-describe('UrlMarkdown', () => {
+describe('markdownLink', () => {
   it('should return the anchor name with the correct URL markdown', () => {
-    window.location.href = 'https://example.com/edit/some-page';
-    const anchoreName = 'Fate of Animals';
+    const anchorName = 'Fate of Animals';
+    const url = 'https://example.com/edit/fate-of-animals';
     const expectedMarkdown = '[Fate of Animals](https://example.com/edit/fate-of-animals)';
-    const result = UrlMarkdown(anchoreName);
+
+    const result = markdownLink(anchorName, url);
+
     assert.strictEqual(result, expectedMarkdown);
   });
 
   it('should return the anchor name if URL is null', () => {
-    // Mock the href to be null
-    window.location.href = '';
-    const anchoreName = 'Fate of Animals';
-    const result = UrlMarkdown(anchoreName);
-    assert.strictEqual(result, anchoreName);
+    const anchorName = 'Fate of Animals';
+    const result = markdownLink(anchorName, null);
+    assert.strictEqual(result, anchorName);
   });
 });


### PR DESCRIPTION
* `window.location.href` check still errors trying to access property location on undefined
* Node seems to have special handling for window as `window != undefined ? ...` still errors 🤷🏻‍♂️
* `typeof window === 'undefined' ? ...` does work.

Autoproject tests pass locally when updated to match the new functionality.

Other QOL changes:
* Use `@ukhomeoffice/asl` for eslint - works in CI/CD and workspace.
* `UrlMarkdown` looked like a class name not a function name, and didn't read as specific to keeping animals alive. I've refactored to take the possibly null url as an argument and renamed to look like a function.
