### PR TITLE
[ASL-4495] Array of options when missing NTS fate had wrong structure

### DIFF
--- a/client/helpers/render-fields-in-protocol.js
+++ b/client/helpers/render-fields-in-protocol.js
@@ -1,20 +1,11 @@
 import NTSFateOfAnimalFields from './nts-field';
 
 export const renderFieldsInProtocol = (fateOfAnimals) => {
-  if (!fateOfAnimals) {
-    return [
-      {'continued-use': {
-        label: 'Continued use on another protocol in this project',
-        value: 'continued-use',
-        reveal: {
-          name: 'continued-use-relevant-project',
-          label: 'Please state the relevant protocol.',
-          type: 'texteditor'
-        }
-      }}];
-  }
-
   const predefinedFields = NTSFateOfAnimalFields();
+
+  if (!fateOfAnimals) {
+    return [predefinedFields['continued-use']];
+  }
 
   // Create an ordered list of fields based on fateOfAnimals
   const orderedFields = [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@asl/projects",
-  "version": "15.5.8",
+  "version": "15.5.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@asl/projects",
-      "version": "15.5.8",
+      "version": "15.5.9",
       "license": "MIT",
       "dependencies": {
         "@asl/service": "^10.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asl/projects",
-  "version": "15.5.8",
+  "version": "15.5.9",
   "description": "ASL PPL prototype",
   "main": "client/external.js",
   "styles": "assets/scss/projects.scss",


### PR DESCRIPTION
Option in array had option in a nested object, so when the component tried to access the value in the top level object it was undefined.

Switched to use option from predefinedFields so we're not defining that option in two places.