### PR TITLE
[ASL-4495] list of fates fields should be an array

### DIFF
--- a/client/pages/sections/protocols/protocols.js
+++ b/client/pages/sections/protocols/protocols.js
@@ -91,7 +91,7 @@ class Protocol extends PureComponent {
     } else {
       // Ensure options array exists and is initialized properly
       _.set(this.props.sections, 'fate.fields[0].options', _.get(this.props.sections, 'fate.fields[0].options', []));
-      this.props.sections.fate.fields[0].options = NTSFateOfAnimalFields();
+      this.props.sections.fate.fields[0].options = Object.values(NTSFateOfAnimalFields());
     }
 
     return editable && this.state.active


### PR DESCRIPTION
When rendering the selected fates options as an unordered list they're expected to be an array. 