### PR TITLE
[ASL-4495]  Fix rendering defects

### DIFF
--- a/client/components/review.js
+++ b/client/components/review.js
@@ -7,6 +7,7 @@ import DiffWindow from './diff-window';
 import ReviewField from './review-field';
 import ChangedBadge from './changed-badge';
 import RAPlaybackHint from './ra-playback-hint';
+import { Markdown } from '@ukhomeoffice/asl-components';
 
 import ErrorBoundary from './error-boundary';
 import classnames from 'classnames';
@@ -33,6 +34,8 @@ class Review extends React.Component {
 
     if (this.props.raPlayback) {
       hint = <RAPlaybackHint {...this.props.raPlayback} hint={hint} />;
+    } else if (!React.isValidElement(hint)) {
+      hint = <Markdown links={true}>{hint}</Markdown>;
     }
 
     const showComments = !this.props.noComments && this.props.type !== 'repeater';

--- a/client/helpers/index.js
+++ b/client/helpers/index.js
@@ -248,7 +248,15 @@ export const isTrainingLicence = values => {
 };
 
 export const getCurrentURLForFateOfAnimals = () => {
-  return typeof window !== 'undefined' ? window.location.href.split('/edit/')[0] + '/edit/fate-of-animals' : null;
+  if (typeof window === 'undefined') return null;
+
+  const href = window.location.href;
+  const splitter = ['/edit/', '/full-application/'].find(urlPart => href.includes(urlPart));
+  if (!splitter) {
+    return null;
+  }
+
+  return typeof window !== 'undefined' ? window.location.href.split(splitter)[0] + `${splitter}fate-of-animals` : null;
 };
 
 export const markdownLink = (linkText, url) => {

--- a/client/schema/v1/index.js
+++ b/client/schema/v1/index.js
@@ -35,6 +35,7 @@ import permissiblePurpose from './permissible-purpose';
 import confirmProtocolsAffected from '../../helpers/confirm-protocols-affected';
 
 import {isTrainingLicence, markdownLink, getCurrentURLForFateOfAnimals} from '../../helpers';
+import NTSFateOfAnimalFields from '../../helpers/nts-field';
 
 export default () => {
   return ({
@@ -1973,7 +1974,7 @@ export default () => {
                   type: 'checkbox',
                   preserveHierarchy: true,
                   className: 'smaller',
-                  options: []
+                  options: Object.values(NTSFateOfAnimalFields())
                 }
               ]
             },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@asl/projects",
-  "version": "15.5.10",
+  "version": "15.5.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@asl/projects",
-      "version": "15.5.10",
+      "version": "15.5.11",
       "license": "MIT",
       "dependencies": {
         "@asl/service": "^10.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asl/projects",
-  "version": "15.5.10",
+  "version": "15.5.11",
   "description": "ASL PPL prototype",
   "main": "client/external.js",
   "styles": "assets/scss/projects.scss",

--- a/test/specs/helpers/url-markdown.js
+++ b/test/specs/helpers/url-markdown.js
@@ -2,16 +2,33 @@ import assert from 'assert';
 import {getCurrentURLForFateOfAnimals, markdownLink} from '../../../client/helpers';
 
 // Mock window object
-global.window = {
-  location: {
-    href: 'https://example.com/edit/some-page'
+let prevWindow = null;
+
+const mockLocationHref = (url) => {
+  prevWindow = global.window;
+  global.window = {
+    location: {
+      href: url
+    }
+  };
+};
+
+const resetWindow = () => {
+  if (prevWindow !== null) {
+    global.window = prevWindow;
+    prevWindow = null;
   }
 };
 
 describe('getCurrentURLForFateOfAnimals', () => {
+  afterEach(() => { resetWindow(); });
+
   it('should return the correct URL for fate-of-animals', () => {
+    mockLocationHref('https://example.com/edit/some-page');
     const expectedURL = 'https://example.com/edit/fate-of-animals';
+
     const result = getCurrentURLForFateOfAnimals();
+
     assert.strictEqual(result, expectedURL);
   });
 
@@ -26,6 +43,23 @@ describe('getCurrentURLForFateOfAnimals', () => {
 
     // eslint-disable-next-line no-global-assign
     window = prevWindow;
+  });
+
+  it('should return an appropriate url when rendering the full application', () => {
+    mockLocationHref('https://example.com/full-application/some-page');
+    const expectedURL = 'https://example.com/full-application/fate-of-animals';
+
+    const result = getCurrentURLForFateOfAnimals();
+
+    assert.strictEqual(result, expectedURL);
+  });
+
+  it('should return null when rendering on an unexpected page', () => {
+    mockLocationHref('https://example.com/some-other-route/some-page');
+
+    const result = getCurrentURLForFateOfAnimals();
+
+    assert.strictEqual(result, null);
   });
 });
 
@@ -42,7 +76,9 @@ describe('markdownLink', () => {
 
   it('should return the anchor name if URL is null', () => {
     const anchorName = 'Fate of Animals';
+
     const result = markdownLink(anchorName, null);
+
     assert.strictEqual(result, anchorName);
   });
 });


### PR DESCRIPTION
* Hint in review now rendered as markdown to match logic in form inputs [@ukhomeoffice/react-components](https://github.com/UKHomeOffice/react-components/blob/main/src/forms/input.jsx#L34-L36)
* Building NTS link also needs to account for `full-application` url
* Default options to all. When rendered as field these will always be overridden, but when used to reference how to render options that were selected (e.g. in PDF) it's easiest to have all available, as only selected options actually get shown.