### PR TITLE
[ASL-4495] Fix PDF styling regression

### DIFF
--- a/client/components/review.js
+++ b/client/components/review.js
@@ -34,8 +34,8 @@ class Review extends React.Component {
 
     if (this.props.raPlayback) {
       hint = <RAPlaybackHint {...this.props.raPlayback} hint={hint} />;
-    } else if (!React.isValidElement(hint)) {
-      hint = <Markdown links={true}>{hint}</Markdown>;
+    } else if (hint && !React.isValidElement(hint)) {
+      hint = <Markdown links={true} unwrapSingleLine>{hint}</Markdown>;
     }
 
     const showComments = !this.props.noComments && this.props.type !== 'repeater';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@asl/projects",
-  "version": "15.5.11",
+  "version": "15.5.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@asl/projects",
-      "version": "15.5.11",
+      "version": "15.5.12",
       "license": "MIT",
       "dependencies": {
         "@asl/service": "^10.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asl/projects",
-  "version": "15.5.11",
+  "version": "15.5.12",
   "description": "ASL PPL prototype",
   "main": "client/external.js",
   "styles": "assets/scss/projects.scss",

--- a/views/pdf/index.jsx
+++ b/views/pdf/index.jsx
@@ -10,9 +10,9 @@ const PDF = ({ schemaVersion }) => {
     <StaticRouter>
       <Route path="/" component={Component} />
     </StaticRouter>
-  )
+  );
 };
 
-const mapStateToProps = ({ application: { schemaVersion } }) => ({ schemaVersion })
+const mapStateToProps = ({ application: { schemaVersion } }) => ({ schemaVersion });
 
 export default connect(mapStateToProps)(PDF);


### PR DESCRIPTION
By default, the markdown renders the contents in a paragraph. This created nested paragraphs weren't getting the hint text styling in the pdf. The Markdown component provides functionality to wrap in a span instead when there is a single line which renders with the expected styles.

Also minor code style change that was highlighted by IDE when investigating