### PR TITLE
[ASL-4495] Style hints in ReactMarkdown

### DIFF
--- a/client/components/review.js
+++ b/client/components/review.js
@@ -35,7 +35,13 @@ class Review extends React.Component {
     if (this.props.raPlayback) {
       hint = <RAPlaybackHint {...this.props.raPlayback} hint={hint} />;
     } else if (hint && !React.isValidElement(hint)) {
-      hint = <Markdown links={true} unwrapSingleLine>{hint}</Markdown>;
+      hint = <Markdown links={true} paragraphProps={{className: 'grey'}}>{hint}</Markdown>;
+    } else if (hint) {
+      // Defensive: keep old behaviour for unexpected edge cases
+      hint = <p className="grey">{hint}</p>;
+    } else {
+      // Cast all falsy hints to null, so react definitely renders nothing
+      hint = null;
     }
 
     const showComments = !this.props.noComments && this.props.type !== 'repeater';
@@ -70,9 +76,7 @@ class Review extends React.Component {
             />
           )
         }
-        {
-          hint && <p className="grey">{hint}</p>
-        }
+        {hint}
         {
           this.replay()
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "@asl/projects",
-  "version": "15.5.12",
+  "version": "15.5.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@asl/projects",
-      "version": "15.5.12",
+      "version": "15.5.13",
       "license": "MIT",
       "dependencies": {
         "@asl/service": "^10.3.2",
         "@asl/slate-edit-table": "0.0.3",
         "@babel/core": "^7.24.4",
         "@redux-devtools/extension": "^3.3.0",
-        "@ukhomeoffice/asl-components": "13.5.0",
+        "@ukhomeoffice/asl-components": "13.6.0",
         "@ukhomeoffice/asl-constants": "^2.1.5",
         "@ukhomeoffice/asl-slate-edit-list": "0.0.8",
         "@ukhomeoffice/frontend-toolkit": "^3.0.0",
@@ -129,6 +129,45 @@
       },
       "peerDependencies": {
         "webpack": "^5.69.1"
+      }
+    },
+    "node_modules/@asl/service/node_modules/@ukhomeoffice/asl-components": {
+      "version": "13.5.0",
+      "resolved": "https://npm.pkg.github.com/download/@ukhomeoffice/asl-components/13.5.0/3a2dbc35f0511193e5e2fc12398271e89234a853",
+      "integrity": "sha512-NauUA8/HaRgI2KD6SH3N82aATWmGtUet9fM7dqbOOW+pD8Hd27PFgKNBrhQVrZilV+c1Rzm/wPRhT6LPch45aw==",
+      "license": "MIT",
+      "dependencies": {
+        "@ukhomeoffice/asl-constants": "^2.1.5",
+        "@ukhomeoffice/asl-dictionary": "^2.1.0",
+        "@ukhomeoffice/react-components": "^1.0.0",
+        "accessible-autocomplete": "^2.0.3",
+        "classnames": "^2.2.6",
+        "date-fns": "^3.6.0",
+        "diff": "^4.0.1",
+        "lodash": "^4.17.21",
+        "moment": "^2.29.4",
+        "mustache": "^3.0.1",
+        "qs": "^6.6.1",
+        "react": "^16.9.0",
+        "react-markdown": "^6.0.2",
+        "react-redux": "^7.1.0",
+        "redux": "^4.0.1",
+        "remark-breaks": "^2.0.2",
+        "shasum": "^1.0.2",
+        "url": "^0.11.0",
+        "uuid": "^8.3.2"
+      }
+    },
+    "node_modules/@asl/service/node_modules/@ukhomeoffice/asl-components/node_modules/mustache": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-3.2.1.tgz",
+      "integrity": "sha512-RERvMFdLpaFfSRIEe632yDm5nsd0SDKn8hGmcUwswnyiE5mtdZLDybtHAz6hjJhawokF0hXvGLtx9mrQfm6FkA==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      },
+      "engines": {
+        "npm": ">=1.4.0"
       }
     },
     "node_modules/@asl/slate-edit-table": {
@@ -2323,9 +2362,10 @@
       "integrity": "sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA=="
     },
     "node_modules/@ukhomeoffice/asl-components": {
-      "version": "13.5.0",
-      "resolved": "https://npm.pkg.github.com/download/@ukhomeoffice/asl-components/13.5.0/3a2dbc35f0511193e5e2fc12398271e89234a853",
-      "integrity": "sha512-NauUA8/HaRgI2KD6SH3N82aATWmGtUet9fM7dqbOOW+pD8Hd27PFgKNBrhQVrZilV+c1Rzm/wPRhT6LPch45aw==",
+      "version": "13.6.0",
+      "resolved": "https://npm.pkg.github.com/download/@ukhomeoffice/asl-components/13.6.0/6baab4459d65d3078efcbd615405ca4202c2efcb",
+      "integrity": "sha512-Dzq04B9Fqh8KsrLFKuMakOBsZMTsdN159MPvi2Mjy/Z7mFUxxRQUwMUqLlTsgvRkKZGPG99aKFuNrBw+bbCHUg==",
+      "license": "MIT",
       "dependencies": {
         "@ukhomeoffice/asl-constants": "^2.1.5",
         "@ukhomeoffice/asl-dictionary": "^2.1.0",
@@ -4022,9 +4062,10 @@
       "integrity": "sha512-FKbOCOQ5QRB3VlIbl1LZQefWIYwszlBloaXcY2rbfpu9ioJnNh3TK03YtIDKDo3WKBi8u+YV4+Fn2CkEozgf4w=="
     },
     "node_modules/elliptic": {
-      "version": "6.5.6",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.6.tgz",
-      "integrity": "sha512-mpzdtpeCLuS3BmE3pO3Cpp5bbjlOPY2Q0PgoF+Od1XZrHLYI28Xe3ossCmYCQt11FQKEYd9+PF8jymTvtWJSHQ==",
+      "version": "6.5.7",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.7.tgz",
+      "integrity": "sha512-ESVCtTwiA+XhY3wyh24QqRGBoP3rEdDUl3EDUUo9tft074fi19IrdpH7hLCMMP3CIj7jb3W96rn8lt/BqIlt5Q==",
+      "license": "MIT",
       "dependencies": {
         "bn.js": "^4.11.9",
         "brorand": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asl/projects",
-  "version": "15.5.12",
+  "version": "15.5.13",
   "description": "ASL PPL prototype",
   "main": "client/external.js",
   "styles": "assets/scss/projects.scss",
@@ -28,7 +28,7 @@
     "@asl/slate-edit-table": "0.0.3",
     "@babel/core": "^7.24.4",
     "@redux-devtools/extension": "^3.3.0",
-    "@ukhomeoffice/asl-components": "13.5.0",
+    "@ukhomeoffice/asl-components": "13.6.0",
     "@ukhomeoffice/asl-constants": "^2.1.5",
     "@ukhomeoffice/asl-slate-edit-list": "0.0.8",
     "@ukhomeoffice/frontend-toolkit": "^3.0.0",


### PR DESCRIPTION
When using unwrapSingleLine there were some hints (e.g. aims) with multiple lines that still rendered nested p tags, breaking the PDF styling