### PR TITLE
[ASL-4495] Change deselection behavior

### DIFF
--- a/client/helpers/has-existing-data-for-checkbox.js
+++ b/client/helpers/has-existing-data-for-checkbox.js
@@ -1,24 +1,33 @@
+function checkNodes(nodes) {
+  for (let node of nodes) {
+    if (node.object === 'text' && node.text && node.text.trim() !== '') {
+      return true;
+    }
+    if (node.object === 'block' && node.nodes && checkNodes(node.nodes)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function checkField(field) {
+  return field && field.document && field.document.nodes && checkNodes(field.document.nodes);
+}
+
+function hasKeptAliveData(project) {
+  return [
+    project['keeping-alive-complete'] ||
+    checkField(project['keeping-animals-alive-determine']) ||
+    checkField(project['keeping-animals-alive-supervised']) ||
+    checkField(project['kept-alive-animals'])
+  ].some(field => field === true);
+}
+
 /**
  * @desc Takes @param project:Object and @param checkboxValue: String. Checks if there is any existing data in the nodes of the NTS [fate-of-animal] fields associated with the checkbox value.
  * @returns {Object} An object containing the checkbox value and a boolean indicating if there is existing data.
  * */
 const hasExistingDataForCheckbox = (project, checkboxValue) => {
-  const checkNodes = (nodes) => {
-    for (let node of nodes) {
-      if (node.object === 'text' && node.text && node.text.trim() !== '') {
-        return true;
-      }
-      if (node.object === 'block' && node.nodes && checkNodes(node.nodes)) {
-        return true;
-      }
-    }
-    return false;
-  };
-
-  const checkField = (field) => {
-    return field && field.document && field.document.nodes && checkNodes(field.document.nodes);
-  };
-
   let hasData = false;
 
   if (checkboxValue === 'killed' || checkboxValue === 'used-in-other-projects') {
@@ -41,12 +50,7 @@ const hasExistingDataForCheckbox = (project, checkboxValue) => {
   } else {
     switch (checkboxValue) {
       case 'kept-alive':
-        hasData = [
-          project['keeping-alive-complete'] ||
-                    checkField(project['keeping-animals-alive-determine']) ||
-                    checkField(project['keeping-animals-alive-supervised']) ||
-                    checkField(project['kept-alive-animals'])
-        ].some(field => field === true);
+        hasData = hasKeptAliveData(project);
         break;
       case 'rehomed':
         hasData = [
@@ -55,7 +59,8 @@ const hasExistingDataForCheckbox = (project, checkboxValue) => {
                     checkField(project['rehoming-healthy']) ||
                     checkField(project['rehoming-other']) ||
                     checkField(project['rehoming-types'])
-        ].some(field => field === true);
+        ].some(field => field === true) ||
+          hasKeptAliveData(project);
         break;
       case 'set-free':
         hasData = [
@@ -67,7 +72,8 @@ const hasExistingDataForCheckbox = (project, checkboxValue) => {
                     checkField(project['setting-free-rehabilitate']) ||
                     checkField(project['setting-free-socialise']) ||
                     project['setting-free-vet']
-        ].some(field => field === true);
+        ].some(field => field === true) ||
+          hasKeptAliveData(project);
         break;
       default:
         hasData = false;

--- a/client/helpers/reset-fields-based-on-checkbox.js
+++ b/client/helpers/reset-fields-based-on-checkbox.js
@@ -3,85 +3,107 @@
  * @returns {Object} An object containing the checkbox value.
  * */
 import cloneDeep from 'lodash/cloneDeep';
+import intersection from 'lodash/intersection';
+
+const defaultEmptyObject = () => ({
+  'object': 'value',
+  'document': {
+    'data': {},
+    'nodes': [
+      {
+        'data': {},
+        'type': 'paragraph',
+        'nodes': [
+          {
+            'text': '',
+            'marks': [],
+            'object': 'text'
+          }
+        ],
+        'object': 'block'
+      }
+    ],
+    'object': 'document'
+  }
+});
 
 const resetFieldsBasedOnCheckbox = (project, checkboxValue) => {
   // Deep clone the project object to avoid mutating it directly and manipulate NTS data fields.
   const newProject = cloneDeep(project);
-  const defaultEmptyObject = {
-    'object': 'value',
-    'document': {
-      'data': {},
-      'nodes': [
-        {
-          'data': {},
-          'type': 'paragraph',
-          'nodes': [
-            {
-              'text': '',
-              'marks': [],
-              'object': 'text'
-            }
-          ],
-          'object': 'block'
-        }
-      ],
-      'object': 'document'
-    }
-  };
+  newProject['fate-of-animals'] = (project['fate-of-animals'] ?? []).filter(v => v !== checkboxValue);
+  let protocolsComplete = project['protocols-complete'];
 
-  if (checkboxValue === 'killed' || checkboxValue === 'used-in-other-projects') {
-    newProject.protocols = newProject.protocols.map(protocol => {
-      if (checkboxValue === 'killed') {
+  newProject.protocols = newProject.protocols.map(protocol => {
+    const updatedProtocol = {
+      ...protocol,
+      fate: (protocol.fate ?? []).filter(value => value !== checkboxValue)
+    };
+
+    // If the protocol previously had this fate, mark it as incomplete
+    updatedProtocol.complete =
+      protocol.complete &&
+      updatedProtocol.fate.length === (protocol.fate ?? []).length;
+
+    protocolsComplete = protocolsComplete && updatedProtocol.complete;
+
+    switch (checkboxValue) {
+      case 'killed':
         return {
-          ...protocol,
-          'method-and-justification': defaultEmptyObject,
-          'non-schedule-1': false,
-          'complete': false
+          ...updatedProtocol,
+          'method-and-justification': defaultEmptyObject(),
+          'non-schedule-1': false
         };
-      } else if (checkboxValue === 'used-in-other-projects') {
+      case 'used-in-other-projects':
         return {
-          ...protocol,
-          'continued-use-relevant-project': defaultEmptyObject,
-          'non-schedule-1': false,
-          'complete': false
+          ...updatedProtocol,
+          'continued-use-relevant-project': defaultEmptyObject()
         };
-      }
-      return protocol; // Return the original protocol if no changes are needed
-    });
-  }
+      default:
+        return updatedProtocol;
+    }
+  });
 
   switch (checkboxValue) {
-    case 'kept-alive':
-      newProject['keeping-alive-complete'] = false;
-      newProject['keeping-animals-alive-determine'] = defaultEmptyObject;
-      newProject['keeping-animals-alive-supervised'] = defaultEmptyObject;
-      newProject['kept-alive-animals'] = defaultEmptyObject;
-      break;
     case 'rehomed':
       newProject['rehoming-complete'] = false;
-      newProject['rehoming-harmful'] = defaultEmptyObject;
-      newProject['rehoming-healthy'] = defaultEmptyObject;
-      newProject['rehoming-other'] = defaultEmptyObject;
-      newProject['rehoming-types'] = defaultEmptyObject;
+      newProject['rehoming-harmful'] = defaultEmptyObject();
+      newProject['rehoming-healthy'] = defaultEmptyObject();
+      newProject['rehoming-other'] = defaultEmptyObject();
+      newProject['rehoming-types'] = defaultEmptyObject();
       break;
     case 'set-free':
       newProject['setting-free-complete'] = false;
-      newProject['setting-free-ensure-not-harmful'] = defaultEmptyObject;
-      newProject['setting-free-health'] = defaultEmptyObject;
-      newProject['setting-free-lost'] = defaultEmptyObject; // Adjusted to match the specified format
-      newProject['setting-free-recapturing'] = defaultEmptyObject;
-      newProject['setting-free-rehabilitate'] = defaultEmptyObject;
-      newProject['setting-free-socialise'] = defaultEmptyObject;
-      newProject['setting-free-competence'] = defaultEmptyObject;
+      newProject['setting-free-ensure-not-harmful'] = defaultEmptyObject();
+      newProject['setting-free-health'] = defaultEmptyObject();
+      newProject['setting-free-lost'] = defaultEmptyObject(); // Adjusted to match the specified format
+      newProject['setting-free-recapturing'] = defaultEmptyObject();
+      newProject['setting-free-rehabilitate'] = defaultEmptyObject();
+      newProject['setting-free-socialise'] = defaultEmptyObject();
+      newProject['setting-free-competence'] = defaultEmptyObject();
       newProject['setting-free-vet'] = false;
       break;
     default:
       break;
   }
 
-  // // Reset other fields
+  // Three of the fate of animals options trigger the kept alive consideration.
+  // Only if none are selected, should it be cleared out.
+  const triggeringOptions = ['kept-alive', 'rehomed', 'set-free'];
+  const questionIsShown = intersection(
+    newProject['fate-of-animals'] ?? [],
+    triggeringOptions
+  ).length > 0;
+
+  if (!questionIsShown) {
+    newProject['keeping-alive-complete'] = false;
+    newProject['keeping-animals-alive-determine'] = defaultEmptyObject();
+    newProject['keeping-animals-alive-supervised'] = defaultEmptyObject();
+    newProject['kept-alive-animals'] = defaultEmptyObject();
+  }
+
+  // Reset other fields
   newProject['fate-of-animals-complete'] = false;
-  newProject['protocols-complete'] = false;
+  newProject['protocols-complete'] = protocolsComplete;
 
   return newProject;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@asl/projects",
-  "version": "15.5.13",
+  "version": "15.5.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@asl/projects",
-      "version": "15.5.13",
+      "version": "15.5.14",
       "license": "MIT",
       "dependencies": {
         "@asl/service": "^10.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asl/projects",
-  "version": "15.5.13",
+  "version": "15.5.14",
   "description": "ASL PPL prototype",
   "main": "client/external.js",
   "styles": "assets/scss/projects.scss",

--- a/test/specs/helpers/has-existing-data-for-checkbox.test.js
+++ b/test/specs/helpers/has-existing-data-for-checkbox.test.js
@@ -1,345 +1,130 @@
 import assert from 'assert';
 import hasExistingDataForCheckbox from '../../../client/helpers/has-existing-data-for-checkbox';
+import cloneDeep from 'lodash/cloneDeep';
+import set from 'lodash/set';
 
-describe('hasExistingDataForCheckbox', () => {
-  const project = {
-    'protocols': [
+const emptyTextArea = {
+  'object': 'value',
+  'document': {
+    'data': {},
+    'nodes': [
       {
-        'method-and-justification': {
-          document: {
-            'data': {},
-            'nodes': [
-              {
-                'data': {},
-                'type': 'paragraph',
-                'nodes': [
-                  {
-                    'text': 'method-and-justification',
-                    'marks': [],
-                    'object': 'text'
-                  }
-                ],
-                'object': 'block'
-              }
-            ],
-            'object': 'document'
+        'data': {},
+        'type': 'paragraph',
+        'nodes': [
+          {
+            'text': '',
+            'marks': [],
+            'object': 'text'
           }
-        },
-        'continued-use-relevant-project': {
-          document: {
-            'data': {},
-            'nodes': [
-              {
-                'data': {},
-                'type': 'paragraph',
-                'nodes': [
-                  {
-                    'text': '',
-                    'marks': [],
-                    'object': 'text'
-                  }
-                ],
-                'object': 'block'
-              }
-            ],
-            'object': 'document'
-          }
-        }
+        ],
+        'object': 'block'
       }
     ],
-    'keeping-alive-complete': false,
-    'keeping-animals-alive-determine': {
-      document: {
-        'data': {},
-        'nodes': [
-          {
-            'data': {},
-            'type': 'paragraph',
-            'nodes': [
-              {
-                'text': 'keeping-animals-alive-determine',
-                'marks': [],
-                'object': 'text'
-              }
-            ],
-            'object': 'block'
-          }
-        ],
-        'object': 'document'
-      }
-    },
-    'keeping-animals-alive-supervised': {
-      document: {
-        'data': {},
-        'nodes': [
-          {
-            'data': {},
-            'type': 'paragraph',
-            'nodes': [
-              {
-                'text': '',
-                'marks': [],
-                'object': 'text'
-              }
-            ],
-            'object': 'block'
-          }
-        ],
-        'object': 'document'
-      }
-    },
-    'kept-alive-animals': {
-      document: {
-        'data': {},
-        'nodes': [
-          {
-            'data': {},
-            'type': 'paragraph',
-            'nodes': [
-              {
-                'text': '',
-                'marks': [],
-                'object': 'text'
-              }
-            ],
-            'object': 'block'
-          }
-        ],
-        'object': 'document'
-      }
-    },
-    'rehoming-complete': true,
-    'rehoming-harmful': {
-      document: {
-        'data': {},
-        'nodes': [
-          {
-            'data': {},
-            'type': 'paragraph',
-            'nodes': [
-              {
-                'text': '',
-                'marks': [],
-                'object': 'text'
-              }
-            ],
-            'object': 'block'
-          }
-        ],
-        'object': 'document'
-      }
-    },
-    'rehoming-healthy': {
-      document: {
-        'data': {},
-        'nodes': [
-          {
-            'data': {},
-            'type': 'paragraph',
-            'nodes': [
-              {
-                'text': '',
-                'marks': [],
-                'object': 'text'
-              }
-            ],
-            'object': 'block'
-          }
-        ],
-        'object': 'document'
-      }
-    },
-    'rehoming-other': {
-      document: {
-        'data': {},
-        'nodes': [
-          {
-            'data': {},
-            'type': 'paragraph',
-            'nodes': [
-              {
-                'text': '',
-                'marks': [],
-                'object': 'text'
-              }
-            ],
-            'object': 'block'
-          }
-        ],
-        'object': 'document'
-      }
-    },
-    'rehoming-types': {
-      document: {
-        'data': {},
-        'nodes': [
-          {
-            'data': {},
-            'type': 'paragraph',
-            'nodes': [
-              {
-                'text': '',
-                'marks': [],
-                'object': 'text'
-              }
-            ],
-            'object': 'block'
-          }
-        ],
-        'object': 'document'
-      }
-    },
-    'setting-free-complete': false,
-    'setting-free-ensure-not-harmful': {
-      document: {
-        'data': {},
-        'nodes': [
-          {
-            'data': {},
-            'type': 'paragraph',
-            'nodes': [
-              {
-                'text': '',
-                'marks': [],
-                'object': 'text'
-              }
-            ],
-            'object': 'block'
-          }
-        ],
-        'object': 'document'
-      }
-    },
-    'setting-free-health': {
-      document: {
-        'data': {},
-        'nodes': [
-          {
-            'data': {},
-            'type': 'paragraph',
-            'nodes': [
-              {
-                'text': 'Healthy cub',
-                'marks': [],
-                'object': 'text'
-              }
-            ],
-            'object': 'block'
-          }
-        ],
-        'object': 'document'
-      }
-    },
-    'setting-free-lost': {
-      document: {
-        'data': {},
-        'nodes': [
-          {
-            'data': {},
-            'type': 'paragraph',
-            'nodes': [
-              {
-                'text': '',
-                'marks': [],
-                'object': 'text'
-              }
-            ],
-            'object': 'block'
-          }
-        ],
-        'object': 'document'
-      }
-    },
-    'setting-free-recapturing': {
-      document: {
-        'data': {},
-        'nodes': [
-          {
-            'data': {},
-            'type': 'paragraph',
-            'nodes': [
-              {
-                'text': '',
-                'marks': [],
-                'object': 'text'
-              }
-            ],
-            'object': 'block'
-          }
-        ],
-        'object': 'document'
-      }
-    },
-    'setting-free-rehabilitate': {
-      document: {
-        'data': {},
-        'nodes': [
-          {
-            'data': {},
-            'type': 'paragraph',
-            'nodes': [
-              {
-                'text': '',
-                'marks': [],
-                'object': 'text'
-              }
-            ],
-            'object': 'block'
-          }
-        ],
-        'object': 'document'
-      }
-    },
-    'setting-free-socialise': {
-      document: {
-        'data': {},
-        'nodes': [
-          {
-            'data': {},
-            'type': 'paragraph',
-            'nodes': [
-              {
-                'text': '',
-                'marks': [],
-                'object': 'text'
-              }
-            ],
-            'object': 'block'
-          }
-        ],
-        'object': 'document'
-      }
-    },
-    'setting-free-vet': false
-  };
+    'object': 'document'
+  }
+};
+
+const emptyProject = {
+  'protocols': [
+    {
+      'method-and-justification': cloneDeep(emptyTextArea),
+      'continued-use-relevant-project': cloneDeep(emptyTextArea)
+    }
+  ],
+  'keeping-alive-complete': false,
+  'keeping-animals-alive-determine': cloneDeep(emptyTextArea),
+  'keeping-animals-alive-supervised': cloneDeep(emptyTextArea),
+  'kept-alive-animals': cloneDeep(emptyTextArea),
+  'rehoming-complete': false,
+  'rehoming-harmful': cloneDeep(emptyTextArea),
+  'rehoming-healthy': cloneDeep(emptyTextArea),
+  'rehoming-other': cloneDeep(emptyTextArea),
+  'rehoming-types': cloneDeep(emptyTextArea),
+  'setting-free-complete': false,
+  'setting-free-ensure-not-harmful': cloneDeep(emptyTextArea),
+  'setting-free-health': cloneDeep(emptyTextArea),
+  'setting-free-lost': cloneDeep(emptyTextArea),
+  'setting-free-recapturing': cloneDeep(emptyTextArea),
+  'setting-free-rehabilitate': cloneDeep(emptyTextArea),
+  'setting-free-socialise': cloneDeep(emptyTextArea),
+  'setting-free-vet': false
+};
+
+const textAreaWithText = (text) => {
+  const state = cloneDeep(emptyTextArea);
+  return set(state, 'document.nodes.0.nodes.0.text', text);
+};
+
+describe('hasExistingDataForCheckbox', () => {
+
+  describe('empty project should not have any existing data', () => {
+    for (const value of ['killed', 'used-in-other-projects', 'kept-alive', 'rehomed', 'set-free']) {
+      it(`- ${value}`, () => {
+        const result = hasExistingDataForCheckbox(emptyProject, value);
+        const expectedResult = { checkboxValue: value, hasData: false };
+        assert.deepEqual(result, expectedResult);
+      });
+    }
+  });
 
   it('should return true for "killed" if there is data in "method-and-justification"', () => {
+    const project = set(
+      cloneDeep(emptyProject),
+      'protocols.0.method-and-justification',
+      textAreaWithText('Method and justification')
+    );
+
     const result = hasExistingDataForCheckbox(project, 'killed');
-    const expectedResult = { checkboxValue: 'killed', hasData: true };
-    assert.deepEqual(result, expectedResult);
+
+    assert.deepEqual(result, { checkboxValue: 'killed', hasData: true });
   });
 
   it('should return true for "used-in-other-projects" if there is data in "continued-use-relevant-project"', () => {
+    const project = set(
+      cloneDeep(emptyProject),
+      'protocols.0.continued-use-relevant-project',
+      textAreaWithText('Relevant project')
+    );
+
     const result = hasExistingDataForCheckbox(project, 'used-in-other-projects');
-    const expectedResult = { checkboxValue: 'used-in-other-projects', hasData: false };
-    assert.deepEqual(result, expectedResult);
+
+    assert.deepEqual(result, { checkboxValue: 'used-in-other-projects', hasData: true });
   });
 
-  it('should return true for "kept-alive" if there is data in "keeping-animals-alive-determine"', () => {
-    const result = hasExistingDataForCheckbox(project, 'kept-alive');
-    const expectedResult = { checkboxValue: 'kept-alive', hasData: true };
-    assert.deepEqual(result, expectedResult);
+  describe('should return true for "rehomed", "set-free", and "kept-alive" if there is data in "keeping-animals-alive-determine"', () => {
+    const project = set(
+      cloneDeep(emptyProject),
+      'keeping-animals-alive-determine',
+      textAreaWithText('Keeping animals alive determine')
+    );
+
+    for (const value of ['rehomed', 'set-free', 'kept-alive']) {
+      it(`- ${value}`, () => {
+        const result = hasExistingDataForCheckbox(project, value);
+
+        assert.deepEqual(result, { checkboxValue: value, hasData: true });
+      });
+    }
   });
 
   it('should return true for "rehomed" if "rehoming-complete" is true', () => {
+    const project = set(cloneDeep(emptyProject), 'rehoming-complete', true);
+
     const result = hasExistingDataForCheckbox(project, 'rehomed');
-    const expectedResult = { checkboxValue: 'rehomed', hasData: true };
-    assert.deepEqual(result, expectedResult);
+
+    assert.deepEqual(result, { checkboxValue: 'rehomed', hasData: true });
   });
 
-  it('should return true for "set-free" if there is no data in any of the fields', () => {
+  it('should return true for "set-free" if "setting-free-ensure-not-harmful" has text', () => {
+    const project = set(
+      cloneDeep(emptyProject),
+      'setting-free-ensure-not-harmful',
+      textAreaWithText('Setting free ensure non-harmful')
+    );
+
     const result = hasExistingDataForCheckbox(project, 'set-free');
-    const expectedResult = { checkboxValue: 'set-free', hasData: true };
-    assert.deepEqual(result, expectedResult);
+
+    assert.deepEqual(result, { checkboxValue: 'set-free', hasData: true });
   });
 });


### PR DESCRIPTION
- Kept-alive answers count as existing data for kept-alive, set-free, and rehomed
- Deselecting the last of kept-alive, set-free, or rehomed should be what triggers clearing kept-alive answers
- Clearing an NTS checkbox should deselect that option in all protocols (this was what was causing some to be pre-ticked in UAT demo)
- Individual protocols and the protocol section should only be marked as incomplete if there is a change.