### PR TITLE
[ASSB-1418] Fix accessing fields of undefined when version is RA

### DIFF
--- a/client/schema/index.js
+++ b/client/schema/index.js
@@ -34,16 +34,18 @@ export function getSubsections(schemaVersion) {
       };
     }, {});
 
-  // inject the project licence holder into introductory details
-  const field = [
-    {
-      label: 'Licence holder',
-      name: 'licenceHolder',
-      type: 'holder-name'
-    }
-  ];
+  if (schemaVersion === 1) {
+    // inject the project licence holder into introductory details
+    const field = [
+      {
+        label: 'Licence holder',
+        name: 'licenceHolder',
+        type: 'holder-name'
+      }
+    ];
 
-  subsections['introduction'].fields.splice(1, 0, field);
+    subsections['introduction'].fields.splice(1, 0, field);
+  }
 
   return subsections;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@asl/projects",
-  "version": "15.6.3",
+  "version": "15.6.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@asl/projects",
-      "version": "15.6.3",
+      "version": "15.6.7",
       "license": "MIT",
       "dependencies": {
         "@asl/service": "^10.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asl/projects",
-  "version": "15.6.6",
+  "version": "15.6.7",
   "description": "ASL PPL prototype",
   "main": "client/external.js",
   "styles": "assets/scss/projects.scss",


### PR DESCRIPTION
https://github.com/UKHomeOffice/asl-deployments/blob/failures-22133/tests/actual/E2E-can_submit_a_new_RA-full-chrome-1260x800-dpr-1.png 

When getting subsections for the  'RA' version there is no 'introduction' subsection, so attempting to inject the licence holder field fails.